### PR TITLE
Add slvsocial preconfiguration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,9 @@ endif()
 # ParHIP
 option(PARHIP "build ParHIP" ON)
 
+# stronglvsocial preconfiguration using VieClus
+option(STRONG_LV_SOCIAL "enable stronglvsocial preconfiguration which requires VieClus" OFF)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
@@ -241,3 +244,40 @@ if(PARHIP)
   add_subdirectory(parallel/modified_kahip)
   add_subdirectory(parallel/parallel_src)
 endif()
+
+# VieClus
+if (STRONG_LV_SOCIAL)
+  message(STATUS "Building with VieClus")
+  include(ExternalProject)
+  include(ProcessorCount)
+
+  ProcessorCount(N_CORES)
+  if (N EQUAL 0)
+    set(N_CORES 1)
+  endif ()
+
+  set(VIECLUS_DIR "${CMAKE_BINARY_DIR}/VieClus")
+  set(VIECLUS_PROGRAM library)
+  set(VIECLUS_VARIANT optimized)
+  ExternalProject_Add(VieClus
+          GIT_REPOSITORY https://github.com/danielseemaier/VieClus.git # TODO CHANGE ME
+          GIT_TAG VieClusInterface # TODO CHANGE ME
+          SOURCE_DIR ${VIECLUS_DIR}
+          BUILD_IN_SOURCE 1
+          CONFIGURE_COMMAND ""
+          BUILD_COMMAND scons program=${VIECLUS_PROGRAM} variant=${VIECLUS_VARIANT} -j ${N_CORES}
+          INSTALL_COMMAND cp ${VIECLUS_DIR}/${VIECLUS_VARIANT}/libvieclus.so ${CMAKE_BINARY_DIR}/libvieclus.so
+          )
+
+  set(LIBKAFFPA_VIECLUS_SOURC_FILES
+          lib/community_detection/VieClus_adapter.cpp
+          lib/community_detection/VieClus_adapter.h)
+  add_library(libkaffpa_vieclus ${LIBKAFFPA_VIECLUS_SOURC_FILES})
+  target_compile_definitions(libkaffpa_vieclus PUBLIC USE_VIECLUS)
+  target_link_libraries(libkaffpa_vieclus PUBLIC libvieclus.so)
+  target_include_directories(libkaffpa_vieclus PUBLIC "${VIECLUS_DIR}/interface/")
+  add_dependencies(libkaffpa_vieclus VieClus)
+
+  target_compile_definitions(kaffpa PUBLIC USE_VIECLUS)
+  target_link_libraries(kaffpa libkaffpa_vieclus MPI::MPI_CXX ${CMAKE_BINARY_DIR}/libvieclus.so)
+endif ()

--- a/app/configuration.h
+++ b/app/configuration.h
@@ -29,7 +29,11 @@ class configuration {
 
                 void fastsocial( PartitionConfig & config );
                 void ecosocial( PartitionConfig & config );
-                void strongsocial( PartitionConfig & config ); 
+                void strongsocial( PartitionConfig & config );
+
+#ifdef USE_VIECLUS
+                void slvsocial( PartitionConfig & config );
+#endif
 
                 //void fastsocial_separator( PartitionConfig & config );
                 //void ecosocial_separator( PartitionConfig & config );
@@ -466,7 +470,10 @@ inline void configuration::standard( PartitionConfig & partition_config ) {
         partition_config.distances.push_back(10);
         partition_config.distances.push_back(100);
 
-
+#ifdef USE_VIECLUS
+        partition_config.use_community_detection = false;
+        partition_config.vieclus_time_limit = 0;
+#endif
 
 }
 
@@ -570,5 +577,12 @@ inline void configuration::strongsocial( PartitionConfig & partition_config ) {
         partition_config.ensemble_clusterings         = true;
 
 }
+
+#ifdef USE_VIECLUS
+inline void configuration::slvsocial( PartitionConfig & partition_config ) {
+        strongsocial(partition_config);
+        partition_config.use_community_detection = true;
+}
+#endif
 
 #endif /* end of include guard: CONFIGURATION_3APG5V7Z */

--- a/app/kaffpa.cpp
+++ b/app/kaffpa.cpp
@@ -28,6 +28,10 @@
 #include "random_functions.h"
 #include "timer.h"
 
+#ifdef USE_VIECLUS
+#include "community_detection/VieClus_adapter.h"
+#endif
+
 int main(int argn, char **argv) {
 
         PartitionConfig partition_config;
@@ -70,7 +74,19 @@ int main(int argn, char **argv) {
         random_functions::setSeed(partition_config.seed);
 
         std::cout <<  "graph has " <<  G.number_of_nodes() <<  " nodes and " <<  G.number_of_edges() <<  " edges"  << std::endl;
-        // ***************************** perform partitioning ***************************************       
+        // ***************************** perform partitioning ***************************************
+#ifdef USE_VIECLUS
+        if (partition_config.use_community_detection) {
+            std::vector<int> clustering = VieClus_adapter::instance()
+                    .compute_modularity_clustering(G, partition_config);
+            partition_config.combine = true;
+            G.resizeSecondPartitionIndex(G.number_of_nodes());
+            for (NodeID u = 0; u < G.number_of_nodes(); ++u) {
+                G.setSecondPartitionIndex(u, clustering[u]);
+            }
+        }
+#endif
+
         t.restart();
         graph_partitioner partitioner;
         quality_metrics qm;

--- a/lib/community_detection/VieClus_adapter.cpp
+++ b/lib/community_detection/VieClus_adapter.cpp
@@ -1,0 +1,44 @@
+#include "VieClus_adapter.h"
+
+#include <VieClus_interface.h>
+
+#include "tools/timer.h"
+
+VieClus_adapter::VieClus_adapter() {
+    VieClus::init(nullptr, nullptr);
+}
+
+VieClus_adapter::~VieClus_adapter() {
+    VieClus::finalize();
+}
+
+VieClus_adapter& VieClus_adapter::instance() {
+    static VieClus_adapter adapter;
+    return adapter;
+}
+
+std::vector<int> VieClus_adapter::compute_modularity_clustering(graph_access &G, const PartitionConfig &partition_config) {
+    VieClus::Graph graph{
+            static_cast<int>(G.number_of_nodes()),
+            G.UNSAFE_metis_style_xadj_array(),
+            G.UNSAFE_metis_style_adjncy_array(),
+            G.UNSAFE_metis_style_vwgt_array(),
+            G.UNSAFE_metis_style_adjwgt_array()
+    };
+    int no_clusters = -1;
+    std::vector<int> partition_map(G.number_of_nodes());
+
+    timer vieclus_timer;
+    double modularity = VieClus::run(graph,
+            partition_config.vieclus_time_limit,
+            partition_config.seed,
+            &no_clusters,
+            partition_map.data());
+    std::cout << "modularity: " << modularity << " with " << no_clusters << " clusters in: " << vieclus_timer.elapsed() << " s" << std::endl;
+
+    delete[] graph.xadj;
+    delete[] graph.adjncy;
+    delete[] graph.vwgt;
+    delete[] graph.adjwgt;
+    return partition_map;
+}

--- a/lib/community_detection/VieClus_adapter.h
+++ b/lib/community_detection/VieClus_adapter.h
@@ -1,0 +1,24 @@
+#ifndef KAHIP_VIECLUS_ADAPTER_H
+#define KAHIP_VIECLUS_ADAPTER_H
+
+#include <vector>
+
+#include "data_structure/graph_access.h"
+#include "partition/partition_config.h"
+
+class VieClus_adapter {
+public:
+    VieClus_adapter();
+    ~VieClus_adapter();
+
+    VieClus_adapter(const VieClus_adapter&) = delete;
+    VieClus_adapter(VieClus_adapter&&) = delete;
+    VieClus_adapter& operator=(const VieClus_adapter&) = delete;
+    VieClus_adapter& operator=(VieClus_adapter&&) = delete;
+
+    std::vector<int> compute_modularity_clustering(graph_access &G, const PartitionConfig &partition_config);
+
+    static VieClus_adapter &instance();
+};
+
+#endif // KAHIP_VIECLUS_ADAPTER_H

--- a/lib/partition/partition_config.h
+++ b/lib/partition/partition_config.h
@@ -391,6 +391,11 @@ struct PartitionConfig
         //=======================================
         bool enable_omp;
 
+#ifdef USE_VIECLUS
+        bool use_community_detection;
+        int vieclus_time_limit;
+#endif
+
         void LogDump(FILE *out) const {
         }
 };


### PR DESCRIPTION
Build: `cmake .. -DSTRONG_LV_SOCIAL=On`

Run: `env LD_LIBRARY_PATH=./ ./kaffpa --preconfiguration=slvsocial --k=4 ~/graphs/cnr-2000.graph`

With `STRONG_LV_SOCIAL` enabled, CMake clones the VieClus repository and builds a shared library from it (see PR in the VieClus repository). If you're okay with that and want to merge my VieClus PR, you can change the repository in the CMakeLists.txt (L263, L264) to the official repository. 