### PR TITLE
Install ParHIP header

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,8 +3,8 @@ Required Software Packages
 
 Before you can start you need to install the following software packages:
 
-- Scons (http://www.scons.org/)
-- Argtable (http://argtable.sourceforge.net/)
-- OpenMPI (http://www.open-mpi.de/)
+- CMake (https://cmake.org/)
+- An MPI implementation, e.g., OpenMPI (https://www.open-mpi.org/) or MPICH (https://www.mpich.org)
 
-Once you installed the packages, just type ./compile.sh.
+Once you've installed the packages, just type ./compile_withcmake.sh.
+Alternatively, follow standard CMake install practices.

--- a/parallel/parallel_src/CMakeLists.txt
+++ b/parallel/parallel_src/CMakeLists.txt
@@ -97,7 +97,11 @@ add_library(parhip_interface SHARED interface/parhip_interface.cpp $<TARGET_OBJE
 target_compile_definitions(parhip_interface PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
 target_include_directories(parhip_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)
 target_link_libraries(parhip_interface PRIVATE libmodified_kahip_interface)
-install(TARGETS parhip_interface DESTINATION lib)
+set_target_properties(parhip_interface PROPERTIES PUBLIC_HEADER interface/parhip_interface.h)
+install(TARGETS parhip_interface
+        LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION include
+        )
 
 add_library(parhip_interface_static interface/parhip_interface.cpp $<TARGET_OBJECTS:libparallel>)
 target_compile_definitions(parhip_interface_static PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")


### PR DESCRIPTION
I'll note that it would be convenient to be able to build/install just `libparhip_interface.so`, but this isn't supported. Also, if one uses `cmake -DBUILD_SHARED_LIBS=on`, then `libparhip_interface.so` is incomplete (missing symbols like `kaffpaE`). I'd love if this could be supported, but don't understand the rationale behind the present design.

I assume you'll want other public headers installed, but don't know exactly what those are and this is all I need for PETSc.