### PR TITLE
Add perfectly_balance option to C++ interface for kaffpa

### DIFF
--- a/interface/kaHIP_interface.h
+++ b/interface/kaHIP_interface.h
@@ -29,7 +29,9 @@ const int MAPMODE_BISECTION = 1;
 // part has to be an array of n ints
 void kaffpa(int* n, int* vwgt, int* xadj, 
                    int* adjcwgt, int* adjncy, int* nparts, 
-                   double* imbalance,  bool suppress_output, int seed, int mode, 
+                   double* imbalance,
+                   bool perfectly_balance,
+                   bool suppress_output, int seed, int mode, 
                    int* edgecut, int* part);
 
 // balance constraint on nodes and edges

--- a/misc/example_library_call/interface_test.cpp
+++ b/misc/example_library_call/interface_test.cpp
@@ -32,10 +32,10 @@ int main(int argn, char **argv) {
 
         //void kaffpa(int* n, int* vwgt, int* xadj, 
                    //int* adjcwgt, int* adjncy, int* nparts, 
-                   //double* imbalance,  bool suppress_output, int seed, int mode, 
+                   //double* imbalance,  bool suppress_output, bool perfectly_balance, int seed, int mode, 
                    //int* edgecut, int* part);
 
-        kaffpa(&n, vwgt, xadj, adjcwgt, adjncy, &nparts, &imbalance, false, 0, ECO, & edge_cut, part);
+        kaffpa(&n, vwgt, xadj, adjcwgt, adjncy, &nparts, &imbalance, false, false, 0, ECO, & edge_cut, part);
 
         std::cout <<  "edge cut " <<  edge_cut  << std::endl;
 


### PR DESCRIPTION
I'm using this for some MPI performance experiments and `kaffpa` as written was not producing balanced partitions with unweighted vertices. I saw that the CLI interface had a flag to control this, so I added that option to the C++ interface as well.

Graph partitioning is way outside my wheelhouse so I have no confidence that this is theoretically appropriate or in line with whatever guarantees you folks make with your various algorithms. Is there a better way to force balanced partitions with the C++ interface (perhaps `process_mapping`?)