### PR TITLE
Force process_mapping to return balanced partitions.

### DIFF
--- a/lib/mapping/fast_construct_mapping.cpp
+++ b/lib/mapping/fast_construct_mapping.cpp
@@ -75,9 +75,9 @@ void fast_construct_mapping::construct_initial_mapping_topdown_internal( Partiti
                 std::vector< NodeID > & map_to_original, 
                 std::vector< NodeID > & perm_rank) {
 
+        if( group_sizes.size() == 0 ) return;
         PartitionID num_parts = group_sizes[group_sizes.size()-1];
         if( num_parts == 1 ) {
-                if( group_sizes.size() == 1 ) return;
                 group_sizes.pop_back();
                 return construct_initial_mapping_topdown_internal( config, C, group_sizes, 0, map_to_original, perm_rank);
         } 


### PR DESCRIPTION
This PR forces `process_mapping` in the interface library to return balanced partitions.

Add cycle-refinement after initial partitioning to process_mapping.
The number of desired partitions to the kaffpa call is computed as the product of the hierarchy.
The recursive stopping condition in fast_construct_mapping::construct_initial_mapping_topdown_internal is adjusted to terminate properly even when
the number of paritions is not 1.

Please review carefully these two changes for algorithmic correctness. I do not have a good enough background in the algorithm to know whether they are right.
- to kaHIP_interface.cpp where `k` in the partition configuration is set. I believe this is necessary to create a mapping later of the right size.
- to fast_construct_mapping.cpp where the recursive termination condition was causing an out-of-bounds access to `PartitionID num_parts = group_sizes[group_sizes.size()-1];`. This code would execute even if `group_sizes.size()` was 0

I believe the desired behavior of process_mapping is to balance the partitions. If not, an additional boolean argument could be added to the interface.

This runs to completion for several of my test cases (though I haven't checked the results to see if the mapping is of high quality). The adjustments listed above may have caused the algorthm to misbehave, even if it does not crash.