### PR TITLE
Replaced std::unordered_{set,map} with robin_{set,map}.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ option(USE_ILP "build local ILP improver - introduces dependency on Gurobi" OFF)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/app)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/argtable3-3.0.3)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/extern/robin-map/include/tsl)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/io)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/partition)
@@ -208,6 +209,8 @@ set(NODE_ORDERING_SOURCE_FILES
   lib/node_ordering/ordering_tools.cpp
   lib/node_ordering/reductions.cpp)
 add_library(libnodeordering OBJECT ${NODE_ORDERING_SOURCE_FILES})
+
+#add_subdirectory(extern/robin-map)
 
 # generate targets for each binary
 add_executable(kaffpa app/kaffpa.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping>)

--- a/app/graphchecker.cpp
+++ b/app/graphchecker.cpp
@@ -12,7 +12,8 @@
 #include <sstream>
 #include <limits>
 #include <vector>
-#include <unordered_set>
+
+#include "definitions.h"
 
 using namespace std;
 
@@ -201,7 +202,7 @@ int main(int argn, char **argv)
 
         // check if there are parallel edges
         for( long node = 0; node < nmbNodes; node++) {
-                std::unordered_set< long > seen_adjacent_nodes;
+                extlib::unordered_set< long > seen_adjacent_nodes;
                 for( long e = node_starts[node]; e < node_starts[node + 1]; e++) {
                         long target = adjacent_nodes[e];
                         if( !seen_adjacent_nodes.insert(target).second ) {

--- a/app/ilp_improve.cpp
+++ b/app/ilp_improve.cpp
@@ -74,7 +74,7 @@ int main(int argn, char **argv) {
 
         auto limit_nonzeroes = (size_t) partition_config.ilp_limit_nonzeroes;
         // compute BFS
-        std::unordered_set<NodeID> reachable;
+        extlib::unordered_set<NodeID> reachable;
         ilp.computeBFS(G, reachable, partition_config, limit_nonzeroes);
         PartitionID num_blocks = ilp.computeBlocks(G, reachable, partition_config.k);
         PartitionID no_of_coarse_vertices = reachable.size() + num_blocks;

--- a/extern/robin-map/include/tsl/robin_growth_policy.h
+++ b/extern/robin-map/include/tsl/robin_growth_policy.h
@@ -1,0 +1,406 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_GROWTH_POLICY_H
+#define TSL_ROBIN_GROWTH_POLICY_H
+
+#include <algorithm>
+#include <array>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <ratio>
+#include <stdexcept>
+
+#ifdef TSL_DEBUG
+#define tsl_rh_assert(expr) assert(expr)
+#else
+#define tsl_rh_assert(expr) (static_cast<void>(0))
+#endif
+
+/**
+ * If exceptions are enabled, throw the exception passed in parameter, otherwise
+ * call std::terminate.
+ */
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || \
+     (defined(_MSC_VER) && defined(_CPPUNWIND))) &&        \
+    !defined(TSL_NO_EXCEPTIONS)
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) throw ex(msg)
+#else
+#define TSL_RH_NO_EXCEPTIONS
+#ifdef NDEBUG
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) std::terminate()
+#else
+#include <iostream>
+#define TSL_RH_THROW_OR_TERMINATE(ex, msg) \
+  do {                                     \
+    std::cerr << msg << std::endl;         \
+    std::terminate();                      \
+  } while (0)
+#endif
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define TSL_RH_LIKELY(exp) (__builtin_expect(!!(exp), true))
+#else
+#define TSL_RH_LIKELY(exp) (exp)
+#endif
+
+#define TSL_RH_UNUSED(x) static_cast<void>(x)
+
+namespace tsl {
+namespace rh {
+
+/**
+ * Grow the hash table by a factor of GrowthFactor keeping the bucket count to a
+ * power of two. It allows the table to use a mask operation instead of a modulo
+ * operation to map a hash to a bucket.
+ *
+ * GrowthFactor must be a power of two >= 2.
+ */
+template <std::size_t GrowthFactor>
+class power_of_two_growth_policy {
+ public:
+  /**
+   * Called on the hash table creation and on rehash. The number of buckets for
+   * the table is passed in parameter. This number is a minimum, the policy may
+   * update this value with a higher value if needed (but not lower).
+   *
+   * If 0 is given, min_bucket_count_in_out must still be 0 after the policy
+   * creation and bucket_for_hash must always return 0 in this case.
+   */
+  explicit power_of_two_growth_policy(std::size_t& min_bucket_count_in_out) {
+    if (min_bucket_count_in_out > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (min_bucket_count_in_out > 0) {
+      min_bucket_count_in_out =
+          round_up_to_power_of_two(min_bucket_count_in_out);
+      m_mask = min_bucket_count_in_out - 1;
+    } else {
+      m_mask = 0;
+    }
+  }
+
+  /**
+   * Return the bucket [0, bucket_count()) to which the hash belongs.
+   * If bucket_count() is 0, it must always return 0.
+   */
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return hash & m_mask;
+  }
+
+  /**
+   * Return the number of buckets that should be used on next growth.
+   */
+  std::size_t next_bucket_count() const {
+    if ((m_mask + 1) > max_bucket_count() / GrowthFactor) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    return (m_mask + 1) * GrowthFactor;
+  }
+
+  /**
+   * Return the maximum number of buckets supported by the policy.
+   */
+  std::size_t max_bucket_count() const {
+    // Largest power of two.
+    return (std::numeric_limits<std::size_t>::max() / 2) + 1;
+  }
+
+  /**
+   * Reset the growth policy as if it was created with a bucket count of 0.
+   * After a clear, the policy must always return 0 when bucket_for_hash is
+   * called.
+   */
+  void clear() noexcept { m_mask = 0; }
+
+ private:
+  static std::size_t round_up_to_power_of_two(std::size_t value) {
+    if (is_power_of_two(value)) {
+      return value;
+    }
+
+    if (value == 0) {
+      return 1;
+    }
+
+    --value;
+    for (std::size_t i = 1; i < sizeof(std::size_t) * CHAR_BIT; i *= 2) {
+      value |= value >> i;
+    }
+
+    return value + 1;
+  }
+
+  static constexpr bool is_power_of_two(std::size_t value) {
+    return value != 0 && (value & (value - 1)) == 0;
+  }
+
+ protected:
+  static_assert(is_power_of_two(GrowthFactor) && GrowthFactor >= 2,
+                "GrowthFactor must be a power of two >= 2.");
+
+  std::size_t m_mask;
+};
+
+/**
+ * Grow the hash table by GrowthFactor::num / GrowthFactor::den and use a modulo
+ * to map a hash to a bucket. Slower but it can be useful if you want a slower
+ * growth.
+ */
+template <class GrowthFactor = std::ratio<3, 2>>
+class mod_growth_policy {
+ public:
+  explicit mod_growth_policy(std::size_t& min_bucket_count_in_out) {
+    if (min_bucket_count_in_out > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (min_bucket_count_in_out > 0) {
+      m_mod = min_bucket_count_in_out;
+    } else {
+      m_mod = 1;
+    }
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return hash % m_mod;
+  }
+
+  std::size_t next_bucket_count() const {
+    if (m_mod == max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    const double next_bucket_count =
+        std::ceil(double(m_mod) * REHASH_SIZE_MULTIPLICATION_FACTOR);
+    if (!std::isnormal(next_bucket_count)) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    if (next_bucket_count > double(max_bucket_count())) {
+      return max_bucket_count();
+    } else {
+      return std::size_t(next_bucket_count);
+    }
+  }
+
+  std::size_t max_bucket_count() const { return MAX_BUCKET_COUNT; }
+
+  void clear() noexcept { m_mod = 1; }
+
+ private:
+  static constexpr double REHASH_SIZE_MULTIPLICATION_FACTOR =
+      1.0 * GrowthFactor::num / GrowthFactor::den;
+  static const std::size_t MAX_BUCKET_COUNT =
+      std::size_t(double(std::numeric_limits<std::size_t>::max() /
+                         REHASH_SIZE_MULTIPLICATION_FACTOR));
+
+  static_assert(REHASH_SIZE_MULTIPLICATION_FACTOR >= 1.1,
+                "Growth factor should be >= 1.1.");
+
+  std::size_t m_mod;
+};
+
+namespace detail {
+
+#if SIZE_MAX >= ULLONG_MAX
+#define TSL_RH_NB_PRIMES 51
+#elif SIZE_MAX >= ULONG_MAX
+#define TSL_RH_NB_PRIMES 40
+#else
+#define TSL_RH_NB_PRIMES 23
+#endif
+
+static constexpr const std::array<std::size_t, TSL_RH_NB_PRIMES> PRIMES = {{
+    1u,
+    5u,
+    17u,
+    29u,
+    37u,
+    53u,
+    67u,
+    79u,
+    97u,
+    131u,
+    193u,
+    257u,
+    389u,
+    521u,
+    769u,
+    1031u,
+    1543u,
+    2053u,
+    3079u,
+    6151u,
+    12289u,
+    24593u,
+    49157u,
+#if SIZE_MAX >= ULONG_MAX
+    98317ul,
+    196613ul,
+    393241ul,
+    786433ul,
+    1572869ul,
+    3145739ul,
+    6291469ul,
+    12582917ul,
+    25165843ul,
+    50331653ul,
+    100663319ul,
+    201326611ul,
+    402653189ul,
+    805306457ul,
+    1610612741ul,
+    3221225473ul,
+    4294967291ul,
+#endif
+#if SIZE_MAX >= ULLONG_MAX
+    6442450939ull,
+    12884901893ull,
+    25769803751ull,
+    51539607551ull,
+    103079215111ull,
+    206158430209ull,
+    412316860441ull,
+    824633720831ull,
+    1649267441651ull,
+    3298534883309ull,
+    6597069766657ull,
+#endif
+}};
+
+template <unsigned int IPrime>
+static constexpr std::size_t mod(std::size_t hash) {
+  return hash % PRIMES[IPrime];
+}
+
+// MOD_PRIME[iprime](hash) returns hash % PRIMES[iprime]. This table allows for
+// faster modulo as the compiler can optimize the modulo code better with a
+// constant known at the compilation.
+static constexpr const std::array<std::size_t (*)(std::size_t),
+                                  TSL_RH_NB_PRIMES>
+    MOD_PRIME = {{
+        &mod<0>,  &mod<1>,  &mod<2>,  &mod<3>,  &mod<4>,  &mod<5>,
+        &mod<6>,  &mod<7>,  &mod<8>,  &mod<9>,  &mod<10>, &mod<11>,
+        &mod<12>, &mod<13>, &mod<14>, &mod<15>, &mod<16>, &mod<17>,
+        &mod<18>, &mod<19>, &mod<20>, &mod<21>, &mod<22>,
+#if SIZE_MAX >= ULONG_MAX
+        &mod<23>, &mod<24>, &mod<25>, &mod<26>, &mod<27>, &mod<28>,
+        &mod<29>, &mod<30>, &mod<31>, &mod<32>, &mod<33>, &mod<34>,
+        &mod<35>, &mod<36>, &mod<37>, &mod<38>, &mod<39>,
+#endif
+#if SIZE_MAX >= ULLONG_MAX
+        &mod<40>, &mod<41>, &mod<42>, &mod<43>, &mod<44>, &mod<45>,
+        &mod<46>, &mod<47>, &mod<48>, &mod<49>, &mod<50>,
+#endif
+    }};
+
+}  // namespace detail
+
+/**
+ * Grow the hash table by using prime numbers as bucket count. Slower than
+ * tsl::rh::power_of_two_growth_policy in general but will probably distribute
+ * the values around better in the buckets with a poor hash function.
+ *
+ * To allow the compiler to optimize the modulo operation, a lookup table is
+ * used with constant primes numbers.
+ *
+ * With a switch the code would look like:
+ * \code
+ * switch(iprime) { // iprime is the current prime of the hash table
+ *     case 0: hash % 5ul;
+ *             break;
+ *     case 1: hash % 17ul;
+ *             break;
+ *     case 2: hash % 29ul;
+ *             break;
+ *     ...
+ * }
+ * \endcode
+ *
+ * Due to the constant variable in the modulo the compiler is able to optimize
+ * the operation by a series of multiplications, substractions and shifts.
+ *
+ * The 'hash % 5' could become something like 'hash - (hash * 0xCCCCCCCD) >> 34)
+ * * 5' in a 64 bits environment.
+ */
+class prime_growth_policy {
+ public:
+  explicit prime_growth_policy(std::size_t& min_bucket_count_in_out) {
+    auto it_prime = std::lower_bound(
+        detail::PRIMES.begin(), detail::PRIMES.end(), min_bucket_count_in_out);
+    if (it_prime == detail::PRIMES.end()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    m_iprime = static_cast<unsigned int>(
+        std::distance(detail::PRIMES.begin(), it_prime));
+    if (min_bucket_count_in_out > 0) {
+      min_bucket_count_in_out = *it_prime;
+    } else {
+      min_bucket_count_in_out = 0;
+    }
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+    return detail::MOD_PRIME[m_iprime](hash);
+  }
+
+  std::size_t next_bucket_count() const {
+    if (m_iprime + 1 >= detail::PRIMES.size()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The hash table exceeds its maximum size.");
+    }
+
+    return detail::PRIMES[m_iprime + 1];
+  }
+
+  std::size_t max_bucket_count() const { return detail::PRIMES.back(); }
+
+  void clear() noexcept { m_iprime = 0; }
+
+ private:
+  unsigned int m_iprime;
+
+  static_assert(std::numeric_limits<decltype(m_iprime)>::max() >=
+                    detail::PRIMES.size(),
+                "The type of m_iprime is not big enough.");
+};
+
+}  // namespace rh
+}  // namespace tsl
+
+#endif

--- a/extern/robin-map/include/tsl/robin_hash.h
+++ b/extern/robin-map/include/tsl/robin_hash.h
@@ -1,0 +1,1625 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_HASH_H
+#define TSL_ROBIN_HASH_H
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "robin_growth_policy.h"
+
+namespace tsl {
+
+namespace detail_robin_hash {
+
+template <typename T>
+struct make_void {
+  using type = void;
+};
+
+template <typename T, typename = void>
+struct has_is_transparent : std::false_type {};
+
+template <typename T>
+struct has_is_transparent<T,
+                          typename make_void<typename T::is_transparent>::type>
+    : std::true_type {};
+
+template <typename U>
+struct is_power_of_two_policy : std::false_type {};
+
+template <std::size_t GrowthFactor>
+struct is_power_of_two_policy<tsl::rh::power_of_two_growth_policy<GrowthFactor>>
+    : std::true_type {};
+
+// Only available in C++17, we need to be compatible with C++11
+template <class T>
+const T& clamp(const T& v, const T& lo, const T& hi) {
+  return std::min(hi, std::max(lo, v));
+}
+
+template <typename T, typename U>
+static T numeric_cast(U value,
+                      const char* error_message = "numeric_cast() failed.") {
+  T ret = static_cast<T>(value);
+  if (static_cast<U>(ret) != value) {
+    TSL_RH_THROW_OR_TERMINATE(std::runtime_error, error_message);
+  }
+
+  const bool is_same_signedness =
+      (std::is_unsigned<T>::value && std::is_unsigned<U>::value) ||
+      (std::is_signed<T>::value && std::is_signed<U>::value);
+  if (!is_same_signedness && (ret < T{}) != (value < U{})) {
+    TSL_RH_THROW_OR_TERMINATE(std::runtime_error, error_message);
+  }
+
+  return ret;
+}
+
+template <class T, class Deserializer>
+static T deserialize_value(Deserializer& deserializer) {
+  // MSVC < 2017 is not conformant, circumvent the problem by removing the
+  // template keyword
+#if defined(_MSC_VER) && _MSC_VER < 1910
+  return deserializer.Deserializer::operator()<T>();
+#else
+  return deserializer.Deserializer::template operator()<T>();
+#endif
+}
+
+/**
+ * Fixed size type used to represent size_type values on serialization. Need to
+ * be big enough to represent a std::size_t on 32 and 64 bits platforms, and
+ * must be the same size on both platforms.
+ */
+using slz_size_type = std::uint64_t;
+static_assert(std::numeric_limits<slz_size_type>::max() >=
+                  std::numeric_limits<std::size_t>::max(),
+              "slz_size_type must be >= std::size_t");
+
+using truncated_hash_type = std::uint32_t;
+
+/**
+ * Helper class that stores a truncated hash if StoreHash is true and nothing
+ * otherwise.
+ */
+template <bool StoreHash>
+class bucket_entry_hash {
+ public:
+  bool bucket_hash_equal(std::size_t /*hash*/) const noexcept { return true; }
+
+  truncated_hash_type truncated_hash() const noexcept { return 0; }
+
+ protected:
+  void set_hash(truncated_hash_type /*hash*/) noexcept {}
+};
+
+template <>
+class bucket_entry_hash<true> {
+ public:
+  bool bucket_hash_equal(std::size_t hash) const noexcept {
+    return m_hash == truncated_hash_type(hash);
+  }
+
+  truncated_hash_type truncated_hash() const noexcept { return m_hash; }
+
+ protected:
+  void set_hash(truncated_hash_type hash) noexcept {
+    m_hash = truncated_hash_type(hash);
+  }
+
+ private:
+  truncated_hash_type m_hash;
+};
+
+/**
+ * Each bucket entry has:
+ * - A value of type `ValueType`.
+ * - An integer to store how far the value of the bucket, if any, is from its
+ * ideal bucket (ex: if the current bucket 5 has the value 'foo' and
+ * `hash('foo') % nb_buckets` == 3, `dist_from_ideal_bucket()` will return 2 as
+ * the current value of the bucket is two buckets away from its ideal bucket) If
+ * there is no value in the bucket (i.e. `empty()` is true)
+ * `dist_from_ideal_bucket()` will be < 0.
+ * - A marker which tells us if the bucket is the last bucket of the bucket
+ * array (useful for the iterator of the hash table).
+ * - If `StoreHash` is true, 32 bits of the hash of the value, if any, are also
+ * stored in the bucket. If the size of the hash is more than 32 bits, it is
+ * truncated. We don't store the full hash as storing the hash is a potential
+ * opportunity to use the unused space due to the alignment of the bucket_entry
+ * structure. We can thus potentially store the hash without any extra space
+ *   (which would not be possible with 64 bits of the hash).
+ */
+template <typename ValueType, bool StoreHash>
+class bucket_entry : public bucket_entry_hash<StoreHash> {
+  using bucket_hash = bucket_entry_hash<StoreHash>;
+
+ public:
+  using value_type = ValueType;
+  using distance_type = std::int16_t;
+
+  bucket_entry() noexcept
+      : bucket_hash(),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(false) {
+    tsl_rh_assert(empty());
+  }
+
+  bucket_entry(bool last_bucket) noexcept
+      : bucket_hash(),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(last_bucket) {
+    tsl_rh_assert(empty());
+  }
+
+  bucket_entry(const bucket_entry& other) noexcept(
+      std::is_nothrow_copy_constructible<value_type>::value)
+      : bucket_hash(other),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(other.m_last_bucket) {
+    if (!other.empty()) {
+      ::new (static_cast<void*>(std::addressof(m_value)))
+          value_type(other.value());
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+    }
+  }
+
+  /**
+   * Never really used, but still necessary as we must call resize on an empty
+   * `std::vector<bucket_entry>`. and we need to support move-only types. See
+   * robin_hash constructor for details.
+   */
+  bucket_entry(bucket_entry&& other) noexcept(
+      std::is_nothrow_move_constructible<value_type>::value)
+      : bucket_hash(std::move(other)),
+        m_dist_from_ideal_bucket(EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET),
+        m_last_bucket(other.m_last_bucket) {
+    if (!other.empty()) {
+      ::new (static_cast<void*>(std::addressof(m_value)))
+          value_type(std::move(other.value()));
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+    }
+  }
+
+  bucket_entry& operator=(const bucket_entry& other) noexcept(
+      std::is_nothrow_copy_constructible<value_type>::value) {
+    if (this != &other) {
+      clear();
+
+      bucket_hash::operator=(other);
+      if (!other.empty()) {
+        ::new (static_cast<void*>(std::addressof(m_value)))
+            value_type(other.value());
+      }
+
+      m_dist_from_ideal_bucket = other.m_dist_from_ideal_bucket;
+      m_last_bucket = other.m_last_bucket;
+    }
+
+    return *this;
+  }
+
+  bucket_entry& operator=(bucket_entry&&) = delete;
+
+  ~bucket_entry() noexcept { clear(); }
+
+  void clear() noexcept {
+    if (!empty()) {
+      destroy_value();
+      m_dist_from_ideal_bucket = EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+    }
+  }
+
+  bool empty() const noexcept {
+    return m_dist_from_ideal_bucket == EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+  }
+
+  value_type& value() noexcept {
+    tsl_rh_assert(!empty());
+    return *reinterpret_cast<value_type*>(std::addressof(m_value));
+  }
+
+  const value_type& value() const noexcept {
+    tsl_rh_assert(!empty());
+    return *reinterpret_cast<const value_type*>(std::addressof(m_value));
+  }
+
+  distance_type dist_from_ideal_bucket() const noexcept {
+    return m_dist_from_ideal_bucket;
+  }
+
+  bool last_bucket() const noexcept { return m_last_bucket; }
+
+  void set_as_last_bucket() noexcept { m_last_bucket = true; }
+
+  template <typename... Args>
+  void set_value_of_empty_bucket(distance_type dist_from_ideal_bucket,
+                                 truncated_hash_type hash,
+                                 Args&&... value_type_args) {
+    tsl_rh_assert(dist_from_ideal_bucket >= 0);
+    tsl_rh_assert(empty());
+
+    ::new (static_cast<void*>(std::addressof(m_value)))
+        value_type(std::forward<Args>(value_type_args)...);
+    this->set_hash(hash);
+    m_dist_from_ideal_bucket = dist_from_ideal_bucket;
+
+    tsl_rh_assert(!empty());
+  }
+
+  void swap_with_value_in_bucket(distance_type& dist_from_ideal_bucket,
+                                 truncated_hash_type& hash, value_type& value) {
+    tsl_rh_assert(!empty());
+
+    using std::swap;
+    swap(value, this->value());
+    swap(dist_from_ideal_bucket, m_dist_from_ideal_bucket);
+
+    if (StoreHash) {
+      const truncated_hash_type tmp_hash = this->truncated_hash();
+      this->set_hash(hash);
+      hash = tmp_hash;
+    } else {
+      // Avoid warning of unused variable if StoreHash is false
+      TSL_RH_UNUSED(hash);
+    }
+  }
+
+  static truncated_hash_type truncate_hash(std::size_t hash) noexcept {
+    return truncated_hash_type(hash);
+  }
+
+ private:
+  void destroy_value() noexcept {
+    tsl_rh_assert(!empty());
+    value().~value_type();
+  }
+
+ public:
+  static const distance_type EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET = -1;
+  static const distance_type DIST_FROM_IDEAL_BUCKET_LIMIT = 4096;
+  static_assert(DIST_FROM_IDEAL_BUCKET_LIMIT <=
+                    std::numeric_limits<distance_type>::max() - 1,
+                "DIST_FROM_IDEAL_BUCKET_LIMIT must be <= "
+                "std::numeric_limits<distance_type>::max() - 1.");
+
+ private:
+  using storage = typename std::aligned_storage<sizeof(value_type),
+                                                alignof(value_type)>::type;
+
+  distance_type m_dist_from_ideal_bucket;
+  bool m_last_bucket;
+  storage m_value;
+};
+
+/**
+ * Internal common class used by `robin_map` and `robin_set`.
+ *
+ * ValueType is what will be stored by `robin_hash` (usually `std::pair<Key, T>`
+ * for map and `Key` for set).
+ *
+ * `KeySelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the key.
+ *
+ * `ValueSelect` should be a `FunctionObject` which takes a `ValueType` in
+ * parameter and returns a reference to the value. `ValueSelect` should be void
+ * if there is no value (in a set for example).
+ *
+ * The strong exception guarantee only holds if the expression
+ * `std::is_nothrow_swappable<ValueType>::value &&
+ * std::is_nothrow_move_constructible<ValueType>::value` is true.
+ *
+ * Behaviour is undefined if the destructor of `ValueType` throws.
+ */
+template <class ValueType, class KeySelect, class ValueSelect, class Hash,
+          class KeyEqual, class Allocator, bool StoreHash, class GrowthPolicy>
+class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
+ private:
+  template <typename U>
+  using has_mapped_type =
+      typename std::integral_constant<bool, !std::is_same<U, void>::value>;
+
+  static_assert(
+      noexcept(std::declval<GrowthPolicy>().bucket_for_hash(std::size_t(0))),
+      "GrowthPolicy::bucket_for_hash must be noexcept.");
+  static_assert(noexcept(std::declval<GrowthPolicy>().clear()),
+                "GrowthPolicy::clear must be noexcept.");
+
+ public:
+  template <bool IsConst>
+  class robin_iterator;
+
+  using key_type = typename KeySelect::key_type;
+  using value_type = ValueType;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using hasher = Hash;
+  using key_equal = KeyEqual;
+  using allocator_type = Allocator;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = robin_iterator<false>;
+  using const_iterator = robin_iterator<true>;
+
+ private:
+  /**
+   * Either store the hash because we are asked by the `StoreHash` template
+   * parameter or store the hash because it doesn't cost us anything in size and
+   * can be used to speed up rehash.
+   */
+  static constexpr bool STORE_HASH =
+      StoreHash ||
+      ((sizeof(tsl::detail_robin_hash::bucket_entry<value_type, true>) ==
+        sizeof(tsl::detail_robin_hash::bucket_entry<value_type, false>)) &&
+       (sizeof(std::size_t) == sizeof(truncated_hash_type) ||
+        is_power_of_two_policy<GrowthPolicy>::value) &&
+       // Don't store the hash for primitive types with default hash.
+       (!std::is_arithmetic<key_type>::value ||
+        !std::is_same<Hash, std::hash<key_type>>::value));
+
+  /**
+   * Only use the stored hash on lookup if we are explicitly asked. We are not
+   * sure how slow the KeyEqual operation is. An extra comparison may slow
+   * things down with a fast KeyEqual.
+   */
+  static constexpr bool USE_STORED_HASH_ON_LOOKUP = StoreHash;
+
+  /**
+   * We can only use the hash on rehash if the size of the hash type is the same
+   * as the stored one or if we use a power of two modulo. In the case of the
+   * power of two modulo, we just mask the least significant bytes, we just have
+   * to check that the truncated_hash_type didn't truncated more bytes.
+   */
+  static bool USE_STORED_HASH_ON_REHASH(size_type bucket_count) {
+    if (STORE_HASH && sizeof(std::size_t) == sizeof(truncated_hash_type)) {
+      TSL_RH_UNUSED(bucket_count);
+      return true;
+    } else if (STORE_HASH && is_power_of_two_policy<GrowthPolicy>::value) {
+      tsl_rh_assert(bucket_count > 0);
+      return (bucket_count - 1) <=
+             std::numeric_limits<truncated_hash_type>::max();
+    } else {
+      TSL_RH_UNUSED(bucket_count);
+      return false;
+    }
+  }
+
+  using bucket_entry =
+      tsl::detail_robin_hash::bucket_entry<value_type, STORE_HASH>;
+  using distance_type = typename bucket_entry::distance_type;
+
+  using buckets_allocator = typename std::allocator_traits<
+      allocator_type>::template rebind_alloc<bucket_entry>;
+  using buckets_container_type = std::vector<bucket_entry, buckets_allocator>;
+
+ public:
+  /**
+   * The 'operator*()' and 'operator->()' methods return a const reference and
+   * const pointer respectively to the stored value type.
+   *
+   * In case of a map, to get a mutable reference to the value associated to a
+   * key (the '.second' in the stored pair), you have to call 'value()'.
+   *
+   * The main reason for this is that if we returned a `std::pair<Key, T>&`
+   * instead of a `const std::pair<Key, T>&`, the user may modify the key which
+   * will put the map in a undefined state.
+   */
+  template <bool IsConst>
+  class robin_iterator {
+    friend class robin_hash;
+
+   private:
+    using bucket_entry_ptr =
+        typename std::conditional<IsConst, const bucket_entry*,
+                                  bucket_entry*>::type;
+
+    robin_iterator(bucket_entry_ptr bucket) noexcept : m_bucket(bucket) {}
+
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const typename robin_hash::value_type;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type&;
+    using pointer = value_type*;
+
+    robin_iterator() noexcept {}
+
+    // Copy constructor from iterator to const_iterator.
+    template <bool TIsConst = IsConst,
+              typename std::enable_if<TIsConst>::type* = nullptr>
+    robin_iterator(const robin_iterator<!TIsConst>& other) noexcept
+        : m_bucket(other.m_bucket) {}
+
+    robin_iterator(const robin_iterator& other) = default;
+    robin_iterator(robin_iterator&& other) = default;
+    robin_iterator& operator=(const robin_iterator& other) = default;
+    robin_iterator& operator=(robin_iterator&& other) = default;
+
+    const typename robin_hash::key_type& key() const {
+      return KeySelect()(m_bucket->value());
+    }
+
+    template <class U = ValueSelect,
+              typename std::enable_if<has_mapped_type<U>::value &&
+                                      IsConst>::type* = nullptr>
+    const typename U::value_type& value() const {
+      return U()(m_bucket->value());
+    }
+
+    template <class U = ValueSelect,
+              typename std::enable_if<has_mapped_type<U>::value &&
+                                      !IsConst>::type* = nullptr>
+    typename U::value_type& value() const {
+      return U()(m_bucket->value());
+    }
+
+    reference operator*() const { return m_bucket->value(); }
+
+    pointer operator->() const { return std::addressof(m_bucket->value()); }
+
+    robin_iterator& operator++() {
+      while (true) {
+        if (m_bucket->last_bucket()) {
+          ++m_bucket;
+          return *this;
+        }
+
+        ++m_bucket;
+        if (!m_bucket->empty()) {
+          return *this;
+        }
+      }
+    }
+
+    robin_iterator operator++(int) {
+      robin_iterator tmp(*this);
+      ++*this;
+
+      return tmp;
+    }
+
+    friend bool operator==(const robin_iterator& lhs,
+                           const robin_iterator& rhs) {
+      return lhs.m_bucket == rhs.m_bucket;
+    }
+
+    friend bool operator!=(const robin_iterator& lhs,
+                           const robin_iterator& rhs) {
+      return !(lhs == rhs);
+    }
+
+   private:
+    bucket_entry_ptr m_bucket;
+  };
+
+ public:
+#if defined(__cplusplus) && __cplusplus >= 201402L
+  robin_hash(size_type bucket_count, const Hash& hash, const KeyEqual& equal,
+             const Allocator& alloc,
+             float min_load_factor = DEFAULT_MIN_LOAD_FACTOR,
+             float max_load_factor = DEFAULT_MAX_LOAD_FACTOR)
+      : Hash(hash),
+        KeyEqual(equal),
+        GrowthPolicy(bucket_count),
+        m_buckets_data(
+            [&]() {
+              if (bucket_count > max_bucket_count()) {
+                TSL_RH_THROW_OR_TERMINATE(
+                    std::length_error,
+                    "The map exceeds its maximum bucket count.");
+              }
+
+              return bucket_count;
+            }(),
+            alloc),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(bucket_count),
+        m_nb_elements(0),
+        m_grow_on_next_insert(false),
+        m_try_shrink_on_next_insert(false) {
+    if (m_bucket_count > 0) {
+      tsl_rh_assert(!m_buckets_data.empty());
+      m_buckets_data.back().set_as_last_bucket();
+    }
+
+    this->min_load_factor(min_load_factor);
+    this->max_load_factor(max_load_factor);
+  }
+#else
+  /**
+   * C++11 doesn't support the creation of a std::vector with a custom allocator
+   * and 'count' default-inserted elements. The needed contructor `explicit
+   * vector(size_type count, const Allocator& alloc = Allocator());` is only
+   * available in C++14 and later. We thus must resize after using the
+   * `vector(const Allocator& alloc)` constructor.
+   *
+   * We can't use `vector(size_type count, const T& value, const Allocator&
+   * alloc)` as it requires the value T to be copyable.
+   */
+  robin_hash(size_type bucket_count, const Hash& hash, const KeyEqual& equal,
+             const Allocator& alloc,
+             float min_load_factor = DEFAULT_MIN_LOAD_FACTOR,
+             float max_load_factor = DEFAULT_MAX_LOAD_FACTOR)
+      : Hash(hash),
+        KeyEqual(equal),
+        GrowthPolicy(bucket_count),
+        m_buckets_data(alloc),
+        m_buckets(static_empty_bucket_ptr()),
+        m_bucket_count(bucket_count),
+        m_nb_elements(0),
+        m_grow_on_next_insert(false),
+        m_try_shrink_on_next_insert(false) {
+    if (bucket_count > max_bucket_count()) {
+      TSL_RH_THROW_OR_TERMINATE(std::length_error,
+                                "The map exceeds its maximum bucket count.");
+    }
+
+    if (m_bucket_count > 0) {
+      m_buckets_data.resize(m_bucket_count);
+      m_buckets = m_buckets_data.data();
+
+      tsl_rh_assert(!m_buckets_data.empty());
+      m_buckets_data.back().set_as_last_bucket();
+    }
+
+    this->min_load_factor(min_load_factor);
+    this->max_load_factor(max_load_factor);
+  }
+#endif
+
+  robin_hash(const robin_hash& other)
+      : Hash(other),
+        KeyEqual(other),
+        GrowthPolicy(other),
+        m_buckets_data(other.m_buckets_data),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(other.m_bucket_count),
+        m_nb_elements(other.m_nb_elements),
+        m_load_threshold(other.m_load_threshold),
+        m_min_load_factor(other.m_min_load_factor),
+        m_max_load_factor(other.m_max_load_factor),
+        m_grow_on_next_insert(other.m_grow_on_next_insert),
+        m_try_shrink_on_next_insert(other.m_try_shrink_on_next_insert) {}
+
+  robin_hash(robin_hash&& other) noexcept(
+      std::is_nothrow_move_constructible<
+          Hash>::value&& std::is_nothrow_move_constructible<KeyEqual>::value&&
+          std::is_nothrow_move_constructible<GrowthPolicy>::value&&
+              std::is_nothrow_move_constructible<buckets_container_type>::value)
+      : Hash(std::move(static_cast<Hash&>(other))),
+        KeyEqual(std::move(static_cast<KeyEqual&>(other))),
+        GrowthPolicy(std::move(static_cast<GrowthPolicy&>(other))),
+        m_buckets_data(std::move(other.m_buckets_data)),
+        m_buckets(m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data()),
+        m_bucket_count(other.m_bucket_count),
+        m_nb_elements(other.m_nb_elements),
+        m_load_threshold(other.m_load_threshold),
+        m_min_load_factor(other.m_min_load_factor),
+        m_max_load_factor(other.m_max_load_factor),
+        m_grow_on_next_insert(other.m_grow_on_next_insert),
+        m_try_shrink_on_next_insert(other.m_try_shrink_on_next_insert) {
+    other.clear_and_shrink();
+  }
+
+  robin_hash& operator=(const robin_hash& other) {
+    if (&other != this) {
+      Hash::operator=(other);
+      KeyEqual::operator=(other);
+      GrowthPolicy::operator=(other);
+
+      m_buckets_data = other.m_buckets_data;
+      m_buckets = m_buckets_data.empty() ? static_empty_bucket_ptr()
+                                         : m_buckets_data.data();
+      m_bucket_count = other.m_bucket_count;
+      m_nb_elements = other.m_nb_elements;
+
+      m_load_threshold = other.m_load_threshold;
+      m_min_load_factor = other.m_min_load_factor;
+      m_max_load_factor = other.m_max_load_factor;
+
+      m_grow_on_next_insert = other.m_grow_on_next_insert;
+      m_try_shrink_on_next_insert = other.m_try_shrink_on_next_insert;
+    }
+
+    return *this;
+  }
+
+  robin_hash& operator=(robin_hash&& other) {
+    other.swap(*this);
+    other.clear();
+
+    return *this;
+  }
+
+  allocator_type get_allocator() const {
+    return m_buckets_data.get_allocator();
+  }
+
+  /*
+   * Iterators
+   */
+  iterator begin() noexcept {
+    std::size_t i = 0;
+    while (i < m_bucket_count && m_buckets[i].empty()) {
+      i++;
+    }
+
+    return iterator(m_buckets + i);
+  }
+
+  const_iterator begin() const noexcept { return cbegin(); }
+
+  const_iterator cbegin() const noexcept {
+    std::size_t i = 0;
+    while (i < m_bucket_count && m_buckets[i].empty()) {
+      i++;
+    }
+
+    return const_iterator(m_buckets + i);
+  }
+
+  iterator end() noexcept { return iterator(m_buckets + m_bucket_count); }
+
+  const_iterator end() const noexcept { return cend(); }
+
+  const_iterator cend() const noexcept {
+    return const_iterator(m_buckets + m_bucket_count);
+  }
+
+  /*
+   * Capacity
+   */
+  bool empty() const noexcept { return m_nb_elements == 0; }
+
+  size_type size() const noexcept { return m_nb_elements; }
+
+  size_type max_size() const noexcept { return m_buckets_data.max_size(); }
+
+  /*
+   * Modifiers
+   */
+  void clear() noexcept {
+    if (m_min_load_factor > 0.0f) {
+      clear_and_shrink();
+    } else {
+      for (auto& bucket : m_buckets_data) {
+        bucket.clear();
+      }
+
+      m_nb_elements = 0;
+      m_grow_on_next_insert = false;
+    }
+  }
+
+  template <typename P>
+  std::pair<iterator, bool> insert(P&& value) {
+    return insert_impl(KeySelect()(value), std::forward<P>(value));
+  }
+
+  template <typename P>
+  iterator insert_hint(const_iterator hint, P&& value) {
+    if (hint != cend() &&
+        compare_keys(KeySelect()(*hint), KeySelect()(value))) {
+      return mutable_iterator(hint);
+    }
+
+    return insert(std::forward<P>(value)).first;
+  }
+
+  template <class InputIt>
+  void insert(InputIt first, InputIt last) {
+    if (std::is_base_of<
+            std::forward_iterator_tag,
+            typename std::iterator_traits<InputIt>::iterator_category>::value) {
+      const auto nb_elements_insert = std::distance(first, last);
+      const size_type nb_free_buckets = m_load_threshold - size();
+      tsl_rh_assert(m_load_threshold >= size());
+
+      if (nb_elements_insert > 0 &&
+          nb_free_buckets < size_type(nb_elements_insert)) {
+        reserve(size() + size_type(nb_elements_insert));
+      }
+    }
+
+    for (; first != last; ++first) {
+      insert(*first);
+    }
+  }
+
+  template <class K, class M>
+  std::pair<iterator, bool> insert_or_assign(K&& key, M&& obj) {
+    auto it = try_emplace(std::forward<K>(key), std::forward<M>(obj));
+    if (!it.second) {
+      it.first.value() = std::forward<M>(obj);
+    }
+
+    return it;
+  }
+
+  template <class K, class M>
+  iterator insert_or_assign(const_iterator hint, K&& key, M&& obj) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+      auto it = mutable_iterator(hint);
+      it.value() = std::forward<M>(obj);
+
+      return it;
+    }
+
+    return insert_or_assign(std::forward<K>(key), std::forward<M>(obj)).first;
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return insert(value_type(std::forward<Args>(args)...));
+  }
+
+  template <class... Args>
+  iterator emplace_hint(const_iterator hint, Args&&... args) {
+    return insert_hint(hint, value_type(std::forward<Args>(args)...));
+  }
+
+  template <class K, class... Args>
+  std::pair<iterator, bool> try_emplace(K&& key, Args&&... args) {
+    return insert_impl(key, std::piecewise_construct,
+                       std::forward_as_tuple(std::forward<K>(key)),
+                       std::forward_as_tuple(std::forward<Args>(args)...));
+  }
+
+  template <class K, class... Args>
+  iterator try_emplace_hint(const_iterator hint, K&& key, Args&&... args) {
+    if (hint != cend() && compare_keys(KeySelect()(*hint), key)) {
+      return mutable_iterator(hint);
+    }
+
+    return try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+  }
+
+  /**
+   * Here to avoid `template<class K> size_type erase(const K& key)` being used
+   * when we use an `iterator` instead of a `const_iterator`.
+   */
+  iterator erase(iterator pos) {
+    erase_from_bucket(pos);
+
+    /**
+     * Erase bucket used a backward shift after clearing the bucket.
+     * Check if there is a new value in the bucket, if not get the next
+     * non-empty.
+     */
+    if (pos.m_bucket->empty()) {
+      ++pos;
+    }
+
+    m_try_shrink_on_next_insert = true;
+
+    return pos;
+  }
+
+  iterator erase(const_iterator pos) { return erase(mutable_iterator(pos)); }
+
+  iterator erase(const_iterator first, const_iterator last) {
+    if (first == last) {
+      return mutable_iterator(first);
+    }
+
+    auto first_mutable = mutable_iterator(first);
+    auto last_mutable = mutable_iterator(last);
+    for (auto it = first_mutable.m_bucket; it != last_mutable.m_bucket; ++it) {
+      if (!it->empty()) {
+        it->clear();
+        m_nb_elements--;
+      }
+    }
+
+    if (last_mutable == end()) {
+      m_try_shrink_on_next_insert = true;
+      return end();
+    }
+
+    /*
+     * Backward shift on the values which come after the deleted values.
+     * We try to move the values closer to their ideal bucket.
+     */
+    std::size_t icloser_bucket =
+        static_cast<std::size_t>(first_mutable.m_bucket - m_buckets);
+    std::size_t ito_move_closer_value =
+        static_cast<std::size_t>(last_mutable.m_bucket - m_buckets);
+    tsl_rh_assert(ito_move_closer_value > icloser_bucket);
+
+    const std::size_t ireturn_bucket =
+        ito_move_closer_value -
+        std::min(
+            ito_move_closer_value - icloser_bucket,
+            std::size_t(
+                m_buckets[ito_move_closer_value].dist_from_ideal_bucket()));
+
+    while (ito_move_closer_value < m_bucket_count &&
+           m_buckets[ito_move_closer_value].dist_from_ideal_bucket() > 0) {
+      icloser_bucket =
+          ito_move_closer_value -
+          std::min(
+              ito_move_closer_value - icloser_bucket,
+              std::size_t(
+                  m_buckets[ito_move_closer_value].dist_from_ideal_bucket()));
+
+      tsl_rh_assert(m_buckets[icloser_bucket].empty());
+      const distance_type new_distance = distance_type(
+          m_buckets[ito_move_closer_value].dist_from_ideal_bucket() -
+          (ito_move_closer_value - icloser_bucket));
+      m_buckets[icloser_bucket].set_value_of_empty_bucket(
+          new_distance, m_buckets[ito_move_closer_value].truncated_hash(),
+          std::move(m_buckets[ito_move_closer_value].value()));
+      m_buckets[ito_move_closer_value].clear();
+
+      ++icloser_bucket;
+      ++ito_move_closer_value;
+    }
+
+    m_try_shrink_on_next_insert = true;
+
+    return iterator(m_buckets + ireturn_bucket);
+  }
+
+  template <class K>
+  size_type erase(const K& key) {
+    return erase(key, hash_key(key));
+  }
+
+  template <class K>
+  size_type erase(const K& key, std::size_t hash) {
+    auto it = find(key, hash);
+    if (it != end()) {
+      erase_from_bucket(it);
+      m_try_shrink_on_next_insert = true;
+
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  void swap(robin_hash& other) {
+    using std::swap;
+
+    swap(static_cast<Hash&>(*this), static_cast<Hash&>(other));
+    swap(static_cast<KeyEqual&>(*this), static_cast<KeyEqual&>(other));
+    swap(static_cast<GrowthPolicy&>(*this), static_cast<GrowthPolicy&>(other));
+    swap(m_buckets_data, other.m_buckets_data);
+    swap(m_buckets, other.m_buckets);
+    swap(m_bucket_count, other.m_bucket_count);
+    swap(m_nb_elements, other.m_nb_elements);
+    swap(m_load_threshold, other.m_load_threshold);
+    swap(m_min_load_factor, other.m_min_load_factor);
+    swap(m_max_load_factor, other.m_max_load_factor);
+    swap(m_grow_on_next_insert, other.m_grow_on_next_insert);
+    swap(m_try_shrink_on_next_insert, other.m_try_shrink_on_next_insert);
+  }
+
+  /*
+   * Lookup
+   */
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& at(const K& key) {
+    return at(key, hash_key(key));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& at(const K& key, std::size_t hash) {
+    return const_cast<typename U::value_type&>(
+        static_cast<const robin_hash*>(this)->at(key, hash));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  const typename U::value_type& at(const K& key) const {
+    return at(key, hash_key(key));
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  const typename U::value_type& at(const K& key, std::size_t hash) const {
+    auto it = find(key, hash);
+    if (it != cend()) {
+      return it.value();
+    } else {
+      TSL_RH_THROW_OR_TERMINATE(std::out_of_range, "Couldn't find key.");
+    }
+  }
+
+  template <class K, class U = ValueSelect,
+            typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+  typename U::value_type& operator[](K&& key) {
+    return try_emplace(std::forward<K>(key)).first.value();
+  }
+
+  template <class K>
+  size_type count(const K& key) const {
+    return count(key, hash_key(key));
+  }
+
+  template <class K>
+  size_type count(const K& key, std::size_t hash) const {
+    if (find(key, hash) != cend()) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  template <class K>
+  iterator find(const K& key) {
+    return find_impl(key, hash_key(key));
+  }
+
+  template <class K>
+  iterator find(const K& key, std::size_t hash) {
+    return find_impl(key, hash);
+  }
+
+  template <class K>
+  const_iterator find(const K& key) const {
+    return find_impl(key, hash_key(key));
+  }
+
+  template <class K>
+  const_iterator find(const K& key, std::size_t hash) const {
+    return find_impl(key, hash);
+  }
+
+  template <class K>
+  bool contains(const K& key) const {
+    return contains(key, hash_key(key));
+  }
+
+  template <class K>
+  bool contains(const K& key, std::size_t hash) const {
+    return count(key, hash) != 0;
+  }
+
+  template <class K>
+  std::pair<iterator, iterator> equal_range(const K& key) {
+    return equal_range(key, hash_key(key));
+  }
+
+  template <class K>
+  std::pair<iterator, iterator> equal_range(const K& key, std::size_t hash) {
+    iterator it = find(key, hash);
+    return std::make_pair(it, (it == end()) ? it : std::next(it));
+  }
+
+  template <class K>
+  std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+    return equal_range(key, hash_key(key));
+  }
+
+  template <class K>
+  std::pair<const_iterator, const_iterator> equal_range(
+      const K& key, std::size_t hash) const {
+    const_iterator it = find(key, hash);
+    return std::make_pair(it, (it == cend()) ? it : std::next(it));
+  }
+
+  /*
+   * Bucket interface
+   */
+  size_type bucket_count() const { return m_bucket_count; }
+
+  size_type max_bucket_count() const {
+    return std::min(GrowthPolicy::max_bucket_count(),
+                    m_buckets_data.max_size());
+  }
+
+  /*
+   * Hash policy
+   */
+  float load_factor() const {
+    if (bucket_count() == 0) {
+      return 0;
+    }
+
+    return float(m_nb_elements) / float(bucket_count());
+  }
+
+  float min_load_factor() const { return m_min_load_factor; }
+
+  float max_load_factor() const { return m_max_load_factor; }
+
+  void min_load_factor(float ml) {
+    m_min_load_factor = clamp(ml, float(MINIMUM_MIN_LOAD_FACTOR),
+                              float(MAXIMUM_MIN_LOAD_FACTOR));
+  }
+
+  void max_load_factor(float ml) {
+    m_max_load_factor = clamp(ml, float(MINIMUM_MAX_LOAD_FACTOR),
+                              float(MAXIMUM_MAX_LOAD_FACTOR));
+    m_load_threshold = size_type(float(bucket_count()) * m_max_load_factor);
+  }
+
+  void rehash(size_type count) {
+    count = std::max(count,
+                     size_type(std::ceil(float(size()) / max_load_factor())));
+    rehash_impl(count);
+  }
+
+  void reserve(size_type count) {
+    rehash(size_type(std::ceil(float(count) / max_load_factor())));
+  }
+
+  /*
+   * Observers
+   */
+  hasher hash_function() const { return static_cast<const Hash&>(*this); }
+
+  key_equal key_eq() const { return static_cast<const KeyEqual&>(*this); }
+
+  /*
+   * Other
+   */
+  iterator mutable_iterator(const_iterator pos) {
+    return iterator(const_cast<bucket_entry*>(pos.m_bucket));
+  }
+
+  template <class Serializer>
+  void serialize(Serializer& serializer) const {
+    serialize_impl(serializer);
+  }
+
+  template <class Deserializer>
+  void deserialize(Deserializer& deserializer, bool hash_compatible) {
+    deserialize_impl(deserializer, hash_compatible);
+  }
+
+ private:
+  template <class K>
+  std::size_t hash_key(const K& key) const {
+    return Hash::operator()(key);
+  }
+
+  template <class K1, class K2>
+  bool compare_keys(const K1& key1, const K2& key2) const {
+    return KeyEqual::operator()(key1, key2);
+  }
+
+  std::size_t bucket_for_hash(std::size_t hash) const {
+    const std::size_t bucket = GrowthPolicy::bucket_for_hash(hash);
+    tsl_rh_assert(bucket < m_bucket_count ||
+                  (bucket == 0 && m_bucket_count == 0));
+
+    return bucket;
+  }
+
+  template <class U = GrowthPolicy,
+            typename std::enable_if<is_power_of_two_policy<U>::value>::type* =
+                nullptr>
+  std::size_t next_bucket(std::size_t index) const noexcept {
+    tsl_rh_assert(index < bucket_count());
+
+    return (index + 1) & this->m_mask;
+  }
+
+  template <class U = GrowthPolicy,
+            typename std::enable_if<!is_power_of_two_policy<U>::value>::type* =
+                nullptr>
+  std::size_t next_bucket(std::size_t index) const noexcept {
+    tsl_rh_assert(index < bucket_count());
+
+    index++;
+    return (index != bucket_count()) ? index : 0;
+  }
+
+  template <class K>
+  iterator find_impl(const K& key, std::size_t hash) {
+    return mutable_iterator(
+        static_cast<const robin_hash*>(this)->find(key, hash));
+  }
+
+  template <class K>
+  const_iterator find_impl(const K& key, std::size_t hash) const {
+    std::size_t ibucket = bucket_for_hash(hash);
+    distance_type dist_from_ideal_bucket = 0;
+
+    while (dist_from_ideal_bucket <=
+           m_buckets[ibucket].dist_from_ideal_bucket()) {
+      if (TSL_RH_LIKELY(
+              (!USE_STORED_HASH_ON_LOOKUP ||
+               m_buckets[ibucket].bucket_hash_equal(hash)) &&
+              compare_keys(KeySelect()(m_buckets[ibucket].value()), key))) {
+        return const_iterator(m_buckets + ibucket);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    return cend();
+  }
+
+  void erase_from_bucket(iterator pos) {
+    pos.m_bucket->clear();
+    m_nb_elements--;
+
+    /**
+     * Backward shift, swap the empty bucket, previous_ibucket, with the values
+     * on its right, ibucket, until we cross another empty bucket or if the
+     * other bucket has a distance_from_ideal_bucket == 0.
+     *
+     * We try to move the values closer to their ideal bucket.
+     */
+    std::size_t previous_ibucket =
+        static_cast<std::size_t>(pos.m_bucket - m_buckets);
+    std::size_t ibucket = next_bucket(previous_ibucket);
+
+    while (m_buckets[ibucket].dist_from_ideal_bucket() > 0) {
+      tsl_rh_assert(m_buckets[previous_ibucket].empty());
+
+      const distance_type new_distance =
+          distance_type(m_buckets[ibucket].dist_from_ideal_bucket() - 1);
+      m_buckets[previous_ibucket].set_value_of_empty_bucket(
+          new_distance, m_buckets[ibucket].truncated_hash(),
+          std::move(m_buckets[ibucket].value()));
+      m_buckets[ibucket].clear();
+
+      previous_ibucket = ibucket;
+      ibucket = next_bucket(ibucket);
+    }
+  }
+
+  template <class K, class... Args>
+  std::pair<iterator, bool> insert_impl(const K& key,
+                                        Args&&... value_type_args) {
+    const std::size_t hash = hash_key(key);
+
+    std::size_t ibucket = bucket_for_hash(hash);
+    distance_type dist_from_ideal_bucket = 0;
+
+    while (dist_from_ideal_bucket <=
+           m_buckets[ibucket].dist_from_ideal_bucket()) {
+      if ((!USE_STORED_HASH_ON_LOOKUP ||
+           m_buckets[ibucket].bucket_hash_equal(hash)) &&
+          compare_keys(KeySelect()(m_buckets[ibucket].value()), key)) {
+        return std::make_pair(iterator(m_buckets + ibucket), false);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    if (rehash_on_extreme_load()) {
+      ibucket = bucket_for_hash(hash);
+      dist_from_ideal_bucket = 0;
+
+      while (dist_from_ideal_bucket <=
+             m_buckets[ibucket].dist_from_ideal_bucket()) {
+        ibucket = next_bucket(ibucket);
+        dist_from_ideal_bucket++;
+      }
+    }
+
+    if (m_buckets[ibucket].empty()) {
+      m_buckets[ibucket].set_value_of_empty_bucket(
+          dist_from_ideal_bucket, bucket_entry::truncate_hash(hash),
+          std::forward<Args>(value_type_args)...);
+    } else {
+      insert_value(ibucket, dist_from_ideal_bucket,
+                   bucket_entry::truncate_hash(hash),
+                   std::forward<Args>(value_type_args)...);
+    }
+
+    m_nb_elements++;
+    /*
+     * The value will be inserted in ibucket in any case, either because it was
+     * empty or by stealing the bucket (robin hood).
+     */
+    return std::make_pair(iterator(m_buckets + ibucket), true);
+  }
+
+  template <class... Args>
+  void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                    truncated_hash_type hash, Args&&... value_type_args) {
+    value_type value(std::forward<Args>(value_type_args)...);
+    insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
+  }
+
+  void insert_value(std::size_t ibucket, distance_type dist_from_ideal_bucket,
+                    truncated_hash_type hash, value_type&& value) {
+    insert_value_impl(ibucket, dist_from_ideal_bucket, hash, value);
+  }
+
+  /*
+   * We don't use `value_type&& value` as last argument due to a bug in MSVC
+   * when `value_type` is a pointer, The compiler is not able to see the
+   * difference between `std::string*` and `std::string*&&` resulting in a
+   * compilation error.
+   *
+   * The `value` will be in a moved state at the end of the function.
+   */
+  void insert_value_impl(std::size_t ibucket,
+                         distance_type dist_from_ideal_bucket,
+                         truncated_hash_type hash, value_type& value) {
+    m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket, hash,
+                                                 value);
+    ibucket = next_bucket(ibucket);
+    dist_from_ideal_bucket++;
+
+    while (!m_buckets[ibucket].empty()) {
+      if (dist_from_ideal_bucket >
+          m_buckets[ibucket].dist_from_ideal_bucket()) {
+        if (dist_from_ideal_bucket >=
+            bucket_entry::DIST_FROM_IDEAL_BUCKET_LIMIT) {
+          /**
+           * The number of probes is really high, rehash the map on the next
+           * insert. Difficult to do now as rehash may throw an exception.
+           */
+          m_grow_on_next_insert = true;
+        }
+
+        m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
+                                                     hash, value);
+      }
+
+      ibucket = next_bucket(ibucket);
+      dist_from_ideal_bucket++;
+    }
+
+    m_buckets[ibucket].set_value_of_empty_bucket(dist_from_ideal_bucket, hash,
+                                                 std::move(value));
+  }
+
+  void rehash_impl(size_type count) {
+    robin_hash new_table(count, static_cast<Hash&>(*this),
+                         static_cast<KeyEqual&>(*this), get_allocator(),
+                         m_min_load_factor, m_max_load_factor);
+
+    const bool use_stored_hash =
+        USE_STORED_HASH_ON_REHASH(new_table.bucket_count());
+    for (auto& bucket : m_buckets_data) {
+      if (bucket.empty()) {
+        continue;
+      }
+
+      const std::size_t hash =
+          use_stored_hash ? bucket.truncated_hash()
+                          : new_table.hash_key(KeySelect()(bucket.value()));
+
+      new_table.insert_value_on_rehash(new_table.bucket_for_hash(hash), 0,
+                                       bucket_entry::truncate_hash(hash),
+                                       std::move(bucket.value()));
+    }
+
+    new_table.m_nb_elements = m_nb_elements;
+    new_table.swap(*this);
+  }
+
+  void clear_and_shrink() noexcept {
+    GrowthPolicy::clear();
+    m_buckets_data.clear();
+    m_buckets = static_empty_bucket_ptr();
+    m_bucket_count = 0;
+    m_nb_elements = 0;
+    m_load_threshold = 0;
+    m_grow_on_next_insert = false;
+    m_try_shrink_on_next_insert = false;
+  }
+
+  void insert_value_on_rehash(std::size_t ibucket,
+                              distance_type dist_from_ideal_bucket,
+                              truncated_hash_type hash, value_type&& value) {
+    while (true) {
+      if (dist_from_ideal_bucket >
+          m_buckets[ibucket].dist_from_ideal_bucket()) {
+        if (m_buckets[ibucket].empty()) {
+          m_buckets[ibucket].set_value_of_empty_bucket(dist_from_ideal_bucket,
+                                                       hash, std::move(value));
+          return;
+        } else {
+          m_buckets[ibucket].swap_with_value_in_bucket(dist_from_ideal_bucket,
+                                                       hash, value);
+        }
+      }
+
+      dist_from_ideal_bucket++;
+      ibucket = next_bucket(ibucket);
+    }
+  }
+
+  /**
+   * Grow the table if m_grow_on_next_insert is true or we reached the
+   * max_load_factor. Shrink the table if m_try_shrink_on_next_insert is true
+   * (an erase occurred) and we're below the min_load_factor.
+   *
+   * Return true if the table has been rehashed.
+   */
+  bool rehash_on_extreme_load() {
+    if (m_grow_on_next_insert || size() >= m_load_threshold) {
+      rehash_impl(GrowthPolicy::next_bucket_count());
+      m_grow_on_next_insert = false;
+
+      return true;
+    }
+
+    if (m_try_shrink_on_next_insert) {
+      m_try_shrink_on_next_insert = false;
+      if (m_min_load_factor != 0.0f && load_factor() < m_min_load_factor) {
+        reserve(size() + 1);
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  template <class Serializer>
+  void serialize_impl(Serializer& serializer) const {
+    const slz_size_type version = SERIALIZATION_PROTOCOL_VERSION;
+    serializer(version);
+
+    // Indicate if the truncated hash of each bucket is stored. Use a
+    // std::int16_t instead of a bool to avoid the need for the serializer to
+    // support an extra 'bool' type.
+    const std::int16_t hash_stored_for_bucket =
+        static_cast<std::int16_t>(STORE_HASH);
+    serializer(hash_stored_for_bucket);
+
+    const slz_size_type nb_elements = m_nb_elements;
+    serializer(nb_elements);
+
+    const slz_size_type bucket_count = m_buckets_data.size();
+    serializer(bucket_count);
+
+    const float min_load_factor = m_min_load_factor;
+    serializer(min_load_factor);
+
+    const float max_load_factor = m_max_load_factor;
+    serializer(max_load_factor);
+
+    for (const bucket_entry& bucket : m_buckets_data) {
+      if (bucket.empty()) {
+        const std::int16_t empty_bucket =
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET;
+        serializer(empty_bucket);
+      } else {
+        const std::int16_t dist_from_ideal_bucket =
+            bucket.dist_from_ideal_bucket();
+        serializer(dist_from_ideal_bucket);
+        if (STORE_HASH) {
+          const std::uint32_t truncated_hash = bucket.truncated_hash();
+          serializer(truncated_hash);
+        }
+        serializer(bucket.value());
+      }
+    }
+  }
+
+  template <class Deserializer>
+  void deserialize_impl(Deserializer& deserializer, bool hash_compatible) {
+    tsl_rh_assert(m_buckets_data.empty());  // Current hash table must be empty
+
+    const slz_size_type version =
+        deserialize_value<slz_size_type>(deserializer);
+    // For now we only have one version of the serialization protocol.
+    // If it doesn't match there is a problem with the file.
+    if (version != SERIALIZATION_PROTOCOL_VERSION) {
+      TSL_RH_THROW_OR_TERMINATE(std::runtime_error,
+                                "Can't deserialize the ordered_map/set. "
+                                "The protocol version header is invalid.");
+    }
+
+    const bool hash_stored_for_bucket =
+        deserialize_value<std::int16_t>(deserializer) ? true : false;
+    if (hash_compatible && STORE_HASH != hash_stored_for_bucket) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Can't deserialize a map with a different StoreHash "
+          "than the one used during the serialization when "
+          "hash compatibility is used");
+    }
+
+    const slz_size_type nb_elements =
+        deserialize_value<slz_size_type>(deserializer);
+    const slz_size_type bucket_count_ds =
+        deserialize_value<slz_size_type>(deserializer);
+    const float min_load_factor = deserialize_value<float>(deserializer);
+    const float max_load_factor = deserialize_value<float>(deserializer);
+
+    if (min_load_factor < MINIMUM_MIN_LOAD_FACTOR ||
+        min_load_factor > MAXIMUM_MIN_LOAD_FACTOR) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Invalid min_load_factor. Check that the serializer "
+          "and deserializer support floats correctly as they "
+          "can be converted implicitly to ints.");
+    }
+
+    if (max_load_factor < MINIMUM_MAX_LOAD_FACTOR ||
+        max_load_factor > MAXIMUM_MAX_LOAD_FACTOR) {
+      TSL_RH_THROW_OR_TERMINATE(
+          std::runtime_error,
+          "Invalid max_load_factor. Check that the serializer "
+          "and deserializer support floats correctly as they "
+          "can be converted implicitly to ints.");
+    }
+
+    this->min_load_factor(min_load_factor);
+    this->max_load_factor(max_load_factor);
+
+    if (bucket_count_ds == 0) {
+      tsl_rh_assert(nb_elements == 0);
+      return;
+    }
+
+    if (!hash_compatible) {
+      reserve(numeric_cast<size_type>(nb_elements,
+                                      "Deserialized nb_elements is too big."));
+      for (slz_size_type ibucket = 0; ibucket < bucket_count_ds; ibucket++) {
+        const distance_type dist_from_ideal_bucket =
+            deserialize_value<std::int16_t>(deserializer);
+        if (dist_from_ideal_bucket !=
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+          if (hash_stored_for_bucket) {
+            TSL_RH_UNUSED(deserialize_value<std::uint32_t>(deserializer));
+          }
+
+          insert(deserialize_value<value_type>(deserializer));
+        }
+      }
+
+      tsl_rh_assert(nb_elements == size());
+    } else {
+      m_bucket_count = numeric_cast<size_type>(
+          bucket_count_ds, "Deserialized bucket_count is too big.");
+
+      GrowthPolicy::operator=(GrowthPolicy(m_bucket_count));
+      // GrowthPolicy should not modify the bucket count we got from
+      // deserialization
+      if (m_bucket_count != bucket_count_ds) {
+        TSL_RH_THROW_OR_TERMINATE(std::runtime_error,
+                                  "The GrowthPolicy is not the same even "
+                                  "though hash_compatible is true.");
+      }
+
+      m_nb_elements = numeric_cast<size_type>(
+          nb_elements, "Deserialized nb_elements is too big.");
+      m_buckets_data.resize(m_bucket_count);
+      m_buckets = m_buckets_data.data();
+
+      for (bucket_entry& bucket : m_buckets_data) {
+        const distance_type dist_from_ideal_bucket =
+            deserialize_value<std::int16_t>(deserializer);
+        if (dist_from_ideal_bucket !=
+            bucket_entry::EMPTY_MARKER_DIST_FROM_IDEAL_BUCKET) {
+          truncated_hash_type truncated_hash = 0;
+          if (hash_stored_for_bucket) {
+            tsl_rh_assert(hash_stored_for_bucket);
+            truncated_hash = deserialize_value<std::uint32_t>(deserializer);
+          }
+
+          bucket.set_value_of_empty_bucket(
+              dist_from_ideal_bucket, truncated_hash,
+              deserialize_value<value_type>(deserializer));
+        }
+      }
+
+      if (!m_buckets_data.empty()) {
+        m_buckets_data.back().set_as_last_bucket();
+      }
+    }
+  }
+
+ public:
+  static const size_type DEFAULT_INIT_BUCKETS_SIZE = 0;
+
+  static constexpr float DEFAULT_MAX_LOAD_FACTOR = 0.5f;
+  static constexpr float MINIMUM_MAX_LOAD_FACTOR = 0.2f;
+  static constexpr float MAXIMUM_MAX_LOAD_FACTOR = 0.95f;
+
+  static constexpr float DEFAULT_MIN_LOAD_FACTOR = 0.0f;
+  static constexpr float MINIMUM_MIN_LOAD_FACTOR = 0.0f;
+  static constexpr float MAXIMUM_MIN_LOAD_FACTOR = 0.15f;
+
+  static_assert(MINIMUM_MAX_LOAD_FACTOR < MAXIMUM_MAX_LOAD_FACTOR,
+                "MINIMUM_MAX_LOAD_FACTOR should be < MAXIMUM_MAX_LOAD_FACTOR");
+  static_assert(MINIMUM_MIN_LOAD_FACTOR < MAXIMUM_MIN_LOAD_FACTOR,
+                "MINIMUM_MIN_LOAD_FACTOR should be < MAXIMUM_MIN_LOAD_FACTOR");
+  static_assert(MAXIMUM_MIN_LOAD_FACTOR < MINIMUM_MAX_LOAD_FACTOR,
+                "MAXIMUM_MIN_LOAD_FACTOR should be < MINIMUM_MAX_LOAD_FACTOR");
+
+ private:
+  /**
+   * Protocol version currenlty used for serialization.
+   */
+  static const slz_size_type SERIALIZATION_PROTOCOL_VERSION = 1;
+
+  /**
+   * Return an always valid pointer to an static empty bucket_entry with
+   * last_bucket() == true.
+   */
+  bucket_entry* static_empty_bucket_ptr() noexcept {
+    static bucket_entry empty_bucket(true);
+    return &empty_bucket;
+  }
+
+ private:
+  buckets_container_type m_buckets_data;
+
+  /**
+   * Points to m_buckets_data.data() if !m_buckets_data.empty() otherwise points
+   * to static_empty_bucket_ptr. This variable is useful to avoid the cost of
+   * checking if m_buckets_data is empty when trying to find an element.
+   *
+   * TODO Remove m_buckets_data and only use a pointer instead of a
+   * pointer+vector to save some space in the robin_hash object. Manage the
+   * Allocator manually.
+   */
+  bucket_entry* m_buckets;
+
+  /**
+   * Used a lot in find, avoid the call to m_buckets_data.size() which is a bit
+   * slower.
+   */
+  size_type m_bucket_count;
+
+  size_type m_nb_elements;
+
+  size_type m_load_threshold;
+
+  float m_min_load_factor;
+  float m_max_load_factor;
+
+  bool m_grow_on_next_insert;
+
+  /**
+   * We can't shrink down the map on erase operations as the erase methods need
+   * to return the next iterator. Shrinking the map would invalidate all the
+   * iterators and we could not return the next iterator in a meaningful way, On
+   * erase, we thus just indicate on erase that we should try to shrink the hash
+   * table on the next insert if we go below the min_load_factor.
+   */
+  bool m_try_shrink_on_next_insert;
+};
+
+}  // namespace detail_robin_hash
+
+}  // namespace tsl
+
+#endif

--- a/extern/robin-map/include/tsl/robin_map.h
+++ b/extern/robin-map/include/tsl/robin_map.h
@@ -1,0 +1,807 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_MAP_H
+#define TSL_ROBIN_MAP_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "robin_hash.h"
+
+namespace tsl {
+
+/**
+ * Implementation of a hash map using open-addressing and the robin hood hashing
+ * algorithm with backward shift deletion.
+ *
+ * For operations modifying the hash map (insert, erase, rehash, ...), the
+ * strong exception guarantee is only guaranteed when the expression
+ * `std::is_nothrow_swappable<std::pair<Key, T>>::value &&
+ * std::is_nothrow_move_constructible<std::pair<Key, T>>::value` is true,
+ * otherwise if an exception is thrown during the swap or the move, the hash map
+ * may end up in a undefined state. Per the standard a `Key` or `T` with a
+ * noexcept copy constructor and no move constructor also satisfies the
+ * `std::is_nothrow_move_constructible<std::pair<Key, T>>::value` criterion (and
+ * will thus guarantee the strong exception for the map).
+ *
+ * When `StoreHash` is true, 32 bits of the hash are stored alongside the
+ * values. It can improve the performance during lookups if the `KeyEqual`
+ * function takes time (if it engenders a cache-miss for example) as we then
+ * compare the stored hashes before comparing the keys. When
+ * `tsl::rh::power_of_two_growth_policy` is used as `GrowthPolicy`, it may also
+ * speed-up the rehash process as we can avoid to recalculate the hash. When it
+ * is detected that storing the hash will not incur any memory penalty due to
+ * alignment (i.e. `sizeof(tsl::detail_robin_hash::bucket_entry<ValueType,
+ * true>) == sizeof(tsl::detail_robin_hash::bucket_entry<ValueType, false>)`)
+ * and `tsl::rh::power_of_two_growth_policy` is used, the hash will be stored
+ * even if `StoreHash` is false so that we can speed-up the rehash (but it will
+ * not be used on lookups unless `StoreHash` is true).
+ *
+ * `GrowthPolicy` defines how the map grows and consequently how a hash value is
+ * mapped to a bucket. By default the map uses
+ * `tsl::rh::power_of_two_growth_policy`. This policy keeps the number of
+ * buckets to a power of two and uses a mask to map the hash to a bucket instead
+ * of the slow modulo. Other growth policies are available and you may define
+ * your own growth policy, check `tsl::rh::power_of_two_growth_policy` for the
+ * interface.
+ *
+ * `std::pair<Key, T>` must be swappable.
+ *
+ * `Key` and `T` must be copy and/or move constructible.
+ *
+ * If the destructor of `Key` or `T` throws an exception, the behaviour of the
+ * class is undefined.
+ *
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators.
+ *  - insert, emplace, emplace_hint, operator[]: if there is an effective
+ * insert, invalidate the iterators.
+ *  - erase: always invalidate the iterators.
+ */
+template <class Key, class T, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<std::pair<Key, T>>,
+          bool StoreHash = false,
+          class GrowthPolicy = tsl::rh::power_of_two_growth_policy<2>>
+class robin_map {
+ private:
+  template <typename U>
+  using has_is_transparent = tsl::detail_robin_hash::has_is_transparent<U>;
+
+  class KeySelect {
+   public:
+    using key_type = Key;
+
+    const key_type& operator()(const std::pair<Key, T>& key_value) const
+        noexcept {
+      return key_value.first;
+    }
+
+    key_type& operator()(std::pair<Key, T>& key_value) noexcept {
+      return key_value.first;
+    }
+  };
+
+  class ValueSelect {
+   public:
+    using value_type = T;
+
+    const value_type& operator()(const std::pair<Key, T>& key_value) const
+        noexcept {
+      return key_value.second;
+    }
+
+    value_type& operator()(std::pair<Key, T>& key_value) noexcept {
+      return key_value.second;
+    }
+  };
+
+  using ht = detail_robin_hash::robin_hash<std::pair<Key, T>, KeySelect,
+                                           ValueSelect, Hash, KeyEqual,
+                                           Allocator, StoreHash, GrowthPolicy>;
+
+ public:
+  using key_type = typename ht::key_type;
+  using mapped_type = T;
+  using value_type = typename ht::value_type;
+  using size_type = typename ht::size_type;
+  using difference_type = typename ht::difference_type;
+  using hasher = typename ht::hasher;
+  using key_equal = typename ht::key_equal;
+  using allocator_type = typename ht::allocator_type;
+  using reference = typename ht::reference;
+  using const_reference = typename ht::const_reference;
+  using pointer = typename ht::pointer;
+  using const_pointer = typename ht::const_pointer;
+  using iterator = typename ht::iterator;
+  using const_iterator = typename ht::const_iterator;
+
+ public:
+  /*
+   * Constructors
+   */
+  robin_map() : robin_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+
+  explicit robin_map(size_type bucket_count, const Hash& hash = Hash(),
+                     const KeyEqual& equal = KeyEqual(),
+                     const Allocator& alloc = Allocator())
+      : m_ht(bucket_count, hash, equal, alloc) {}
+
+  robin_map(size_type bucket_count, const Allocator& alloc)
+      : robin_map(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  robin_map(size_type bucket_count, const Hash& hash, const Allocator& alloc)
+      : robin_map(bucket_count, hash, KeyEqual(), alloc) {}
+
+  explicit robin_map(const Allocator& alloc)
+      : robin_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_map(bucket_count, hash, equal, alloc) {
+    insert(first, last);
+  }
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_map(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  template <class InputIt>
+  robin_map(InputIt first, InputIt last, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_map(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+  robin_map(std::initializer_list<value_type> init,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_map(init.begin(), init.end(), bucket_count, hash, equal, alloc) {}
+
+  robin_map(std::initializer_list<value_type> init, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_map(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(),
+                  alloc) {}
+
+  robin_map(std::initializer_list<value_type> init, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_map(init.begin(), init.end(), bucket_count, hash, KeyEqual(),
+                  alloc) {}
+
+  robin_map& operator=(std::initializer_list<value_type> ilist) {
+    m_ht.clear();
+
+    m_ht.reserve(ilist.size());
+    m_ht.insert(ilist.begin(), ilist.end());
+
+    return *this;
+  }
+
+  allocator_type get_allocator() const { return m_ht.get_allocator(); }
+
+  /*
+   * Iterators
+   */
+  iterator begin() noexcept { return m_ht.begin(); }
+  const_iterator begin() const noexcept { return m_ht.begin(); }
+  const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+
+  iterator end() noexcept { return m_ht.end(); }
+  const_iterator end() const noexcept { return m_ht.end(); }
+  const_iterator cend() const noexcept { return m_ht.cend(); }
+
+  /*
+   * Capacity
+   */
+  bool empty() const noexcept { return m_ht.empty(); }
+  size_type size() const noexcept { return m_ht.size(); }
+  size_type max_size() const noexcept { return m_ht.max_size(); }
+
+  /*
+   * Modifiers
+   */
+  void clear() noexcept { m_ht.clear(); }
+
+  std::pair<iterator, bool> insert(const value_type& value) {
+    return m_ht.insert(value);
+  }
+
+  template <class P, typename std::enable_if<std::is_constructible<
+                         value_type, P&&>::value>::type* = nullptr>
+  std::pair<iterator, bool> insert(P&& value) {
+    return m_ht.emplace(std::forward<P>(value));
+  }
+
+  std::pair<iterator, bool> insert(value_type&& value) {
+    return m_ht.insert(std::move(value));
+  }
+
+  iterator insert(const_iterator hint, const value_type& value) {
+    return m_ht.insert_hint(hint, value);
+  }
+
+  template <class P, typename std::enable_if<std::is_constructible<
+                         value_type, P&&>::value>::type* = nullptr>
+  iterator insert(const_iterator hint, P&& value) {
+    return m_ht.emplace_hint(hint, std::forward<P>(value));
+  }
+
+  iterator insert(const_iterator hint, value_type&& value) {
+    return m_ht.insert_hint(hint, std::move(value));
+  }
+
+  template <class InputIt>
+  void insert(InputIt first, InputIt last) {
+    m_ht.insert(first, last);
+  }
+
+  void insert(std::initializer_list<value_type> ilist) {
+    m_ht.insert(ilist.begin(), ilist.end());
+  }
+
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj) {
+    return m_ht.insert_or_assign(k, std::forward<M>(obj));
+  }
+
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj) {
+    return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj));
+  }
+
+  template <class M>
+  iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
+  }
+
+  template <class M>
+  iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj) {
+    return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+  }
+
+  /**
+   * Due to the way elements are stored, emplace will need to move or copy the
+   * key-value once. The method is equivalent to
+   * insert(value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return m_ht.emplace(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Due to the way elements are stored, emplace_hint will need to move or copy
+   * the key-value once. The method is equivalent to insert(hint,
+   * value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  iterator emplace_hint(const_iterator hint, Args&&... args) {
+    return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) {
+    return m_ht.try_emplace(k, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
+    return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
+    return m_ht.try_emplace_hint(hint, k, std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
+  iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args) {
+    return m_ht.try_emplace_hint(hint, std::move(k),
+                                 std::forward<Args>(args)...);
+  }
+
+  iterator erase(iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator first, const_iterator last) {
+    return m_ht.erase(first, last);
+  }
+  size_type erase(const key_type& key) { return m_ht.erase(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  size_type erase(const key_type& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key) {
+    return m_ht.erase(key);
+  }
+
+  /**
+   * @copydoc erase(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  void swap(robin_map& other) { other.m_ht.swap(m_ht); }
+
+  /*
+   * Lookup
+   */
+  T& at(const Key& key) { return m_ht.at(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  T& at(const Key& key, std::size_t precalculated_hash) {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  const T& at(const Key& key) const { return m_ht.at(key); }
+
+  /**
+   * @copydoc at(const Key& key, std::size_t precalculated_hash)
+   */
+  const T& at(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  T& at(const K& key) {
+    return m_ht.at(key);
+  }
+
+  /**
+   * @copydoc at(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  T& at(const K& key, std::size_t precalculated_hash) {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc at(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const T& at(const K& key) const {
+    return m_ht.at(key);
+  }
+
+  /**
+   * @copydoc at(const K& key, std::size_t precalculated_hash)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const T& at(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.at(key, precalculated_hash);
+  }
+
+  T& operator[](const Key& key) { return m_ht[key]; }
+  T& operator[](Key&& key) { return m_ht[std::move(key)]; }
+
+  size_type count(const Key& key) const { return m_ht.count(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  size_type count(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key) const {
+    return m_ht.count(key);
+  }
+
+  /**
+   * @copydoc count(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  iterator find(const Key& key) { return m_ht.find(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  iterator find(const Key& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  const_iterator find(const Key& key) const { return m_ht.find(key); }
+
+  /**
+   * @copydoc find(const Key& key, std::size_t precalculated_hash)
+   */
+  const_iterator find(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key) {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key) const {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  bool contains(const Key& key) const { return m_ht.contains(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  bool contains(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key) const {
+    return m_ht.contains(key);
+  }
+
+  /**
+   * @copydoc contains(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  std::pair<iterator, iterator> equal_range(const Key& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  std::pair<iterator, iterator> equal_range(const Key& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+   */
+  std::pair<const_iterator, const_iterator> equal_range(
+      const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(
+      const K& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /*
+   * Bucket interface
+   */
+  size_type bucket_count() const { return m_ht.bucket_count(); }
+  size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+
+  /*
+   *  Hash policy
+   */
+  float load_factor() const { return m_ht.load_factor(); }
+
+  float min_load_factor() const { return m_ht.min_load_factor(); }
+  float max_load_factor() const { return m_ht.max_load_factor(); }
+
+  /**
+   * Set the `min_load_factor` to `ml`. When the `load_factor` of the map goes
+   * below `min_load_factor` after some erase operations, the map will be
+   * shrunk when an insertion occurs. The erase method itself never shrinks
+   * the map.
+   *
+   * The default value of `min_load_factor` is 0.0f, the map never shrinks by
+   * default.
+   */
+  void min_load_factor(float ml) { m_ht.min_load_factor(ml); }
+  void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+
+  void rehash(size_type count) { m_ht.rehash(count); }
+  void reserve(size_type count) { m_ht.reserve(count); }
+
+  /*
+   * Observers
+   */
+  hasher hash_function() const { return m_ht.hash_function(); }
+  key_equal key_eq() const { return m_ht.key_eq(); }
+
+  /*
+   * Other
+   */
+
+  /**
+   * Convert a const_iterator to an iterator.
+   */
+  iterator mutable_iterator(const_iterator pos) {
+    return m_ht.mutable_iterator(pos);
+  }
+
+  /**
+   * Serialize the map through the `serializer` parameter.
+   *
+   * The `serializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> void operator()(const U& value);` where the types
+   * `std::int16_t`, `std::uint32_t`, `std::uint64_t`, `float` and
+   * `std::pair<Key, T>` must be supported for U.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, ...) of the types it serializes in the hands of the `Serializer`
+   * function object if compatibility is required.
+   */
+  template <class Serializer>
+  void serialize(Serializer& serializer) const {
+    m_ht.serialize(serializer);
+  }
+
+  /**
+   * Deserialize a previously serialized map through the `deserializer`
+   * parameter.
+   *
+   * The `deserializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> U operator()();` where the types `std::int16_t`,
+   * `std::uint32_t`, `std::uint64_t`, `float` and `std::pair<Key, T>` must be
+   * supported for U.
+   *
+   * If the deserialized hash map type is hash compatible with the serialized
+   * map, the deserialization process can be sped up by setting
+   * `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and
+   * GrowthPolicy must behave the same way than the ones used on the serialized
+   * map and the StoreHash must have the same value. The `std::size_t` must also
+   * be of the same size as the one on the platform used to serialize the map.
+   * If these criteria are not met, the behaviour is undefined with
+   * `hash_compatible` sets to true.
+   *
+   * The behaviour is undefined if the type `Key` and `T` of the `robin_map` are
+   * not the same as the types used during serialization.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, size of int, ...) of the types it deserializes in the hands of the
+   * `Deserializer` function object if compatibility is required.
+   */
+  template <class Deserializer>
+  static robin_map deserialize(Deserializer& deserializer,
+                               bool hash_compatible = false) {
+    robin_map map(0);
+    map.m_ht.deserialize(deserializer, hash_compatible);
+
+    return map;
+  }
+
+  friend bool operator==(const robin_map& lhs, const robin_map& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    for (const auto& element_lhs : lhs) {
+      const auto it_element_rhs = rhs.find(element_lhs.first);
+      if (it_element_rhs == rhs.cend() ||
+          element_lhs.second != it_element_rhs->second) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  friend bool operator!=(const robin_map& lhs, const robin_map& rhs) {
+    return !operator==(lhs, rhs);
+  }
+
+  friend void swap(robin_map& lhs, robin_map& rhs) { lhs.swap(rhs); }
+
+ private:
+  ht m_ht;
+};
+
+/**
+ * Same as `tsl::robin_map<Key, T, Hash, KeyEqual, Allocator, StoreHash,
+ * tsl::rh::prime_growth_policy>`.
+ */
+template <class Key, class T, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<std::pair<Key, T>>,
+          bool StoreHash = false>
+using robin_pg_map = robin_map<Key, T, Hash, KeyEqual, Allocator, StoreHash,
+                               tsl::rh::prime_growth_policy>;
+
+}  // end namespace tsl
+
+#endif

--- a/extern/robin-map/include/tsl/robin_set.h
+++ b/extern/robin-map/include/tsl/robin_set.h
@@ -1,0 +1,660 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ROBIN_SET_H
+#define TSL_ROBIN_SET_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "robin_hash.h"
+
+namespace tsl {
+
+/**
+ * Implementation of a hash set using open-addressing and the robin hood hashing
+ * algorithm with backward shift deletion.
+ *
+ * For operations modifying the hash set (insert, erase, rehash, ...), the
+ * strong exception guarantee is only guaranteed when the expression
+ * `std::is_nothrow_swappable<Key>::value &&
+ * std::is_nothrow_move_constructible<Key>::value` is true, otherwise if an
+ * exception is thrown during the swap or the move, the hash set may end up in a
+ * undefined state. Per the standard a `Key` with a noexcept copy constructor
+ * and no move constructor also satisfies the
+ * `std::is_nothrow_move_constructible<Key>::value` criterion (and will thus
+ * guarantee the strong exception for the set).
+ *
+ * When `StoreHash` is true, 32 bits of the hash are stored alongside the
+ * values. It can improve the performance during lookups if the `KeyEqual`
+ * function takes time (or engenders a cache-miss for example) as we then
+ * compare the stored hashes before comparing the keys. When
+ * `tsl::rh::power_of_two_growth_policy` is used as `GrowthPolicy`, it may also
+ * speed-up the rehash process as we can avoid to recalculate the hash. When it
+ * is detected that storing the hash will not incur any memory penalty due to
+ * alignment (i.e. `sizeof(tsl::detail_robin_hash::bucket_entry<ValueType,
+ * true>) == sizeof(tsl::detail_robin_hash::bucket_entry<ValueType, false>)`)
+ * and `tsl::rh::power_of_two_growth_policy` is used, the hash will be stored
+ * even if `StoreHash` is false so that we can speed-up the rehash (but it will
+ * not be used on lookups unless `StoreHash` is true).
+ *
+ * `GrowthPolicy` defines how the set grows and consequently how a hash value is
+ * mapped to a bucket. By default the set uses
+ * `tsl::rh::power_of_two_growth_policy`. This policy keeps the number of
+ * buckets to a power of two and uses a mask to set the hash to a bucket instead
+ * of the slow modulo. Other growth policies are available and you may define
+ * your own growth policy, check `tsl::rh::power_of_two_growth_policy` for the
+ * interface.
+ *
+ * `Key` must be swappable.
+ *
+ * `Key` must be copy and/or move constructible.
+ *
+ * If the destructor of `Key` throws an exception, the behaviour of the class is
+ * undefined.
+ *
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators.
+ *  - insert, emplace, emplace_hint, operator[]: if there is an effective
+ * insert, invalidate the iterators.
+ *  - erase: always invalidate the iterators.
+ */
+template <class Key, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<Key>, bool StoreHash = false,
+          class GrowthPolicy = tsl::rh::power_of_two_growth_policy<2>>
+class robin_set {
+ private:
+  template <typename U>
+  using has_is_transparent = tsl::detail_robin_hash::has_is_transparent<U>;
+
+  class KeySelect {
+   public:
+    using key_type = Key;
+
+    const key_type& operator()(const Key& key) const noexcept { return key; }
+
+    key_type& operator()(Key& key) noexcept { return key; }
+  };
+
+  using ht = detail_robin_hash::robin_hash<Key, KeySelect, void, Hash, KeyEqual,
+                                           Allocator, StoreHash, GrowthPolicy>;
+
+ public:
+  using key_type = typename ht::key_type;
+  using value_type = typename ht::value_type;
+  using size_type = typename ht::size_type;
+  using difference_type = typename ht::difference_type;
+  using hasher = typename ht::hasher;
+  using key_equal = typename ht::key_equal;
+  using allocator_type = typename ht::allocator_type;
+  using reference = typename ht::reference;
+  using const_reference = typename ht::const_reference;
+  using pointer = typename ht::pointer;
+  using const_pointer = typename ht::const_pointer;
+  using iterator = typename ht::iterator;
+  using const_iterator = typename ht::const_iterator;
+
+  /*
+   * Constructors
+   */
+  robin_set() : robin_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {}
+
+  explicit robin_set(size_type bucket_count, const Hash& hash = Hash(),
+                     const KeyEqual& equal = KeyEqual(),
+                     const Allocator& alloc = Allocator())
+      : m_ht(bucket_count, hash, equal, alloc) {}
+
+  robin_set(size_type bucket_count, const Allocator& alloc)
+      : robin_set(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  robin_set(size_type bucket_count, const Hash& hash, const Allocator& alloc)
+      : robin_set(bucket_count, hash, KeyEqual(), alloc) {}
+
+  explicit robin_set(const Allocator& alloc)
+      : robin_set(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {}
+
+  template <class InputIt>
+  robin_set(InputIt first, InputIt last,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_set(bucket_count, hash, equal, alloc) {
+    insert(first, last);
+  }
+
+  template <class InputIt>
+  robin_set(InputIt first, InputIt last, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_set(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+  template <class InputIt>
+  robin_set(InputIt first, InputIt last, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_set(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+  robin_set(std::initializer_list<value_type> init,
+            size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+            const Hash& hash = Hash(), const KeyEqual& equal = KeyEqual(),
+            const Allocator& alloc = Allocator())
+      : robin_set(init.begin(), init.end(), bucket_count, hash, equal, alloc) {}
+
+  robin_set(std::initializer_list<value_type> init, size_type bucket_count,
+            const Allocator& alloc)
+      : robin_set(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(),
+                  alloc) {}
+
+  robin_set(std::initializer_list<value_type> init, size_type bucket_count,
+            const Hash& hash, const Allocator& alloc)
+      : robin_set(init.begin(), init.end(), bucket_count, hash, KeyEqual(),
+                  alloc) {}
+
+  robin_set& operator=(std::initializer_list<value_type> ilist) {
+    m_ht.clear();
+
+    m_ht.reserve(ilist.size());
+    m_ht.insert(ilist.begin(), ilist.end());
+
+    return *this;
+  }
+
+  allocator_type get_allocator() const { return m_ht.get_allocator(); }
+
+  /*
+   * Iterators
+   */
+  iterator begin() noexcept { return m_ht.begin(); }
+  const_iterator begin() const noexcept { return m_ht.begin(); }
+  const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+
+  iterator end() noexcept { return m_ht.end(); }
+  const_iterator end() const noexcept { return m_ht.end(); }
+  const_iterator cend() const noexcept { return m_ht.cend(); }
+
+  /*
+   * Capacity
+   */
+  bool empty() const noexcept { return m_ht.empty(); }
+  size_type size() const noexcept { return m_ht.size(); }
+  size_type max_size() const noexcept { return m_ht.max_size(); }
+
+  /*
+   * Modifiers
+   */
+  void clear() noexcept { m_ht.clear(); }
+
+  std::pair<iterator, bool> insert(const value_type& value) {
+    return m_ht.insert(value);
+  }
+
+  std::pair<iterator, bool> insert(value_type&& value) {
+    return m_ht.insert(std::move(value));
+  }
+
+  iterator insert(const_iterator hint, const value_type& value) {
+    return m_ht.insert_hint(hint, value);
+  }
+
+  iterator insert(const_iterator hint, value_type&& value) {
+    return m_ht.insert_hint(hint, std::move(value));
+  }
+
+  template <class InputIt>
+  void insert(InputIt first, InputIt last) {
+    m_ht.insert(first, last);
+  }
+
+  void insert(std::initializer_list<value_type> ilist) {
+    m_ht.insert(ilist.begin(), ilist.end());
+  }
+
+  /**
+   * Due to the way elements are stored, emplace will need to move or copy the
+   * key-value once. The method is equivalent to
+   * insert(value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) {
+    return m_ht.emplace(std::forward<Args>(args)...);
+  }
+
+  /**
+   * Due to the way elements are stored, emplace_hint will need to move or copy
+   * the key-value once. The method is equivalent to insert(hint,
+   * value_type(std::forward<Args>(args)...));
+   *
+   * Mainly here for compatibility with the std::unordered_map interface.
+   */
+  template <class... Args>
+  iterator emplace_hint(const_iterator hint, Args&&... args) {
+    return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+  }
+
+  iterator erase(iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+  iterator erase(const_iterator first, const_iterator last) {
+    return m_ht.erase(first, last);
+  }
+  size_type erase(const key_type& key) { return m_ht.erase(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  size_type erase(const key_type& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key) {
+    return m_ht.erase(key);
+  }
+
+  /**
+   * @copydoc erase(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup to the value if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type erase(const K& key, std::size_t precalculated_hash) {
+    return m_ht.erase(key, precalculated_hash);
+  }
+
+  void swap(robin_set& other) { other.m_ht.swap(m_ht); }
+
+  /*
+   * Lookup
+   */
+  size_type count(const Key& key) const { return m_ht.count(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  size_type count(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key) const {
+    return m_ht.count(key);
+  }
+
+  /**
+   * @copydoc count(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  size_type count(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.count(key, precalculated_hash);
+  }
+
+  iterator find(const Key& key) { return m_ht.find(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  iterator find(const Key& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  const_iterator find(const Key& key) const { return m_ht.find(key); }
+
+  /**
+   * @copydoc find(const Key& key, std::size_t precalculated_hash)
+   */
+  const_iterator find(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key) {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  iterator find(const K& key, std::size_t precalculated_hash) {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key) const {
+    return m_ht.find(key);
+  }
+
+  /**
+   * @copydoc find(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  const_iterator find(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.find(key, precalculated_hash);
+  }
+
+  bool contains(const Key& key) const { return m_ht.contains(key); }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  bool contains(const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key) const {
+    return m_ht.contains(key);
+  }
+
+  /**
+   * @copydoc contains(const K& key) const
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  bool contains(const K& key, std::size_t precalculated_hash) const {
+    return m_ht.contains(key, precalculated_hash);
+  }
+
+  std::pair<iterator, iterator> equal_range(const Key& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  std::pair<iterator, iterator> equal_range(const Key& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  std::pair<const_iterator, const_iterator> equal_range(const Key& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+   */
+  std::pair<const_iterator, const_iterator> equal_range(
+      const Key& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * This overload only participates in the overload resolution if the typedef
+   * KeyEqual::is_transparent exists. If so, K must be hashable and comparable
+   * to Key.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key) {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   *
+   * Use the hash value 'precalculated_hash' instead of hashing the key. The
+   * hash value should be the same as hash_function()(key). Useful to speed-up
+   * the lookup if you already have the hash.
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<iterator, iterator> equal_range(const K& key,
+                                            std::size_t precalculated_hash) {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+    return m_ht.equal_range(key);
+  }
+
+  /**
+   * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+   */
+  template <
+      class K, class KE = KeyEqual,
+      typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+  std::pair<const_iterator, const_iterator> equal_range(
+      const K& key, std::size_t precalculated_hash) const {
+    return m_ht.equal_range(key, precalculated_hash);
+  }
+
+  /*
+   * Bucket interface
+   */
+  size_type bucket_count() const { return m_ht.bucket_count(); }
+  size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+
+  /*
+   *  Hash policy
+   */
+  float load_factor() const { return m_ht.load_factor(); }
+
+  float min_load_factor() const { return m_ht.min_load_factor(); }
+  float max_load_factor() const { return m_ht.max_load_factor(); }
+
+  /**
+   * Set the `min_load_factor` to `ml`. When the `load_factor` of the set goes
+   * below `min_load_factor` after some erase operations, the set will be
+   * shrunk when an insertion occurs. The erase method itself never shrinks
+   * the set.
+   *
+   * The default value of `min_load_factor` is 0.0f, the set never shrinks by
+   * default.
+   */
+  void min_load_factor(float ml) { m_ht.min_load_factor(ml); }
+  void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+
+  void rehash(size_type count) { m_ht.rehash(count); }
+  void reserve(size_type count) { m_ht.reserve(count); }
+
+  /*
+   * Observers
+   */
+  hasher hash_function() const { return m_ht.hash_function(); }
+  key_equal key_eq() const { return m_ht.key_eq(); }
+
+  /*
+   * Other
+   */
+
+  /**
+   * Convert a const_iterator to an iterator.
+   */
+  iterator mutable_iterator(const_iterator pos) {
+    return m_ht.mutable_iterator(pos);
+  }
+
+  friend bool operator==(const robin_set& lhs, const robin_set& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    for (const auto& element_lhs : lhs) {
+      const auto it_element_rhs = rhs.find(element_lhs);
+      if (it_element_rhs == rhs.cend()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Serialize the set through the `serializer` parameter.
+   *
+   * The `serializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> void operator()(const U& value);` where the types
+   * `std::int16_t`, `std::uint32_t`, `std::uint64_t`, `float` and `Key` must be
+   * supported for U.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, ...) of the types it serializes in the hands of the `Serializer`
+   * function object if compatibility is required.
+   */
+  template <class Serializer>
+  void serialize(Serializer& serializer) const {
+    m_ht.serialize(serializer);
+  }
+
+  /**
+   * Deserialize a previously serialized set through the `deserializer`
+   * parameter.
+   *
+   * The `deserializer` parameter must be a function object that supports the
+   * following call:
+   *  - `template<typename U> U operator()();` where the types `std::int16_t`,
+   * `std::uint32_t`, `std::uint64_t`, `float` and `Key` must be supported for
+   * U.
+   *
+   * If the deserialized hash set type is hash compatible with the serialized
+   * set, the deserialization process can be sped up by setting
+   * `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and
+   * GrowthPolicy must behave the same way than the ones used on the serialized
+   * set and the StoreHash must have the same value. The `std::size_t` must also
+   * be of the same size as the one on the platform used to serialize the set.
+   * If these criteria are not met, the behaviour is undefined with
+   * `hash_compatible` sets to true.
+   *
+   * The behaviour is undefined if the type `Key` of the `robin_set` is not the
+   * same as the type used during serialization.
+   *
+   * The implementation leaves binary compatibility (endianness, IEEE 754 for
+   * floats, size of int, ...) of the types it deserializes in the hands of the
+   * `Deserializer` function object if compatibility is required.
+   */
+  template <class Deserializer>
+  static robin_set deserialize(Deserializer& deserializer,
+                               bool hash_compatible = false) {
+    robin_set set(0);
+    set.m_ht.deserialize(deserializer, hash_compatible);
+
+    return set;
+  }
+
+  friend bool operator!=(const robin_set& lhs, const robin_set& rhs) {
+    return !operator==(lhs, rhs);
+  }
+
+  friend void swap(robin_set& lhs, robin_set& rhs) { lhs.swap(rhs); }
+
+ private:
+  ht m_ht;
+};
+
+/**
+ * Same as `tsl::robin_set<Key, Hash, KeyEqual, Allocator, StoreHash,
+ * tsl::rh::prime_growth_policy>`.
+ */
+template <class Key, class Hash = std::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = std::allocator<Key>, bool StoreHash = false>
+using robin_pg_set = robin_set<Key, Hash, KeyEqual, Allocator, StoreHash,
+                               tsl::rh::prime_growth_policy>;
+
+}  // end namespace tsl
+
+#endif

--- a/lib/data_structure/priority_queues/bucket_pq.h
+++ b/lib/data_structure/priority_queues/bucket_pq.h
@@ -9,10 +9,10 @@
 #define BUCKET_PQ_EM8YJPA9
 
 #include <limits>
-#include <unordered_map>
 #include <utility>
 
 #include "priority_queue_interface.h"
+#include "definitions.h"
 
 class bucket_pq : public priority_queue_interface {
         public:
@@ -42,7 +42,7 @@ class bucket_pq : public priority_queue_interface {
                 EdgeWeight m_gain_span;
                 unsigned   m_max_idx; //points to the non-empty bucket with the largest gain
 
-                std::unordered_map<NodeID, std::pair<Count, Gain> > m_queue_index;
+                extlib::unordered_map<NodeID, std::pair<Count, Gain> > m_queue_index;
                 std::vector< std::vector<NodeID> >             m_buckets;
 };
 

--- a/lib/data_structure/priority_queues/maxNodeHeap.h
+++ b/lib/data_structure/priority_queues/maxNodeHeap.h
@@ -10,10 +10,10 @@
 
 #include <limits>
 #include <vector>
-#include <unordered_map>
 #include <execinfo.h>
 
 #include "data_structure/priority_queues/priority_queue_interface.h"
+#include "definitions.h"
 
 typedef int Key;
 
@@ -85,7 +85,7 @@ class maxNodeHeap : public priority_queue_interface {
 
         private:
                 std::vector< PQElement >               m_elements;      // elements that contain the data
-                std::unordered_map<NodeID, int>   m_element_index; // stores index of the node in the m_elements array
+                extlib::unordered_map<NodeID, int>   m_element_index; // stores index of the node in the m_elements array
                 std::vector< std::pair<Key, int> >     m_heap;          // key and index in elements (pointer)
 
                 void siftUp( int pos );

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -15,7 +15,8 @@
 #include "limits.h"
 #include "macros_assertions.h"
 #include "stdio.h"
-
+#include "robin_map.h"
+#include "robin_set.h"
 
 // allows us to disable most of the output during partitioning
 #ifdef KAFFPAOUTPUT
@@ -44,6 +45,19 @@ typedef int 		Color;
 typedef unsigned int 	Count;
 typedef std::vector<NodeID> boundary_starting_nodes;
 typedef long FlowType;
+
+namespace extlib {
+
+template <typename Key, typename T>
+using unordered_map = tsl::robin_map<Key, T>;
+
+template <class Key, class T, class Hash, class KeyEqual>
+using unordered_map_with_custom_hash_and_comparator = tsl::robin_map<Key, T, Hash, KeyEqual>;
+
+template <typename Key>
+using unordered_set = tsl::robin_set<Key>;
+
+}
 
 const EdgeID UNDEFINED_EDGE            = std::numeric_limits<EdgeID>::max();
 const NodeID UNDEFINED_NODE            = std::numeric_limits<NodeID>::max();
@@ -227,7 +241,6 @@ typedef enum {
     CENTER,
     HEAVIEST
 } OverlapPresets;
-
 
 #endif
 

--- a/lib/ilp_improve/ilp_exact.h
+++ b/lib/ilp_improve/ilp_exact.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <unordered_set>
-#include <unordered_map>
 #include <queue>
 #include <vector>
 #include <algorithm>
@@ -21,6 +19,7 @@
 #include "partition/uncoarsening/refinement/cycle_improvements/cycle_refinement.h"
 #include "partition/coarsening/clustering/size_constraint_label_propagation.h"
 #include "partition/graph_partitioner.h"
+#include "definitions.h"
 
 class ilp_exact {
 public:
@@ -37,7 +36,7 @@ public:
         //NodeID numEdges = coarser.number_of_edges() / 2;
 
         //// create index for start edges of nodes
-        //std::unordered_map<EdgeID, NodeID> edge_source;
+        //extlib::unordered_map<EdgeID, NodeID> edge_source;
         //forall_nodes(G, node) {
                     //forall_out_edges(G, e, node) {
                                 //edge_source[e] = node;

--- a/lib/ilp_improve/ilp_helpers.h
+++ b/lib/ilp_improve/ilp_helpers.h
@@ -8,17 +8,16 @@
 #pragma once
 
 #include <algorithm>
-#include <unordered_set>
 
 #include "definitions.h"
 #include "data_structure/graph_access.h"
 
 class ilp_helpers {
 private:
-    std::unordered_set<NodeID> nodes_gain;
+    extlib::unordered_set<NodeID> nodes_gain;
     std::queue<std::vector<NodeID> > q_gain;
     std::vector<size_t> dist_gain;
-    std::unordered_set<NodeID> nodes_cut;
+    extlib::unordered_set<NodeID> nodes_cut;
     std::queue<std::vector<NodeID> > q_cut;
     std::vector<size_t> dist_cut;
     std::vector<PartitionID> pid1;
@@ -121,7 +120,7 @@ public:
     }
 
     std::vector<std::pair<NodeID, Gain>> bestStartNodes(graph_access &G,
-                                                        std::unordered_set<NodeID> & nodesAvailable,
+                                                        extlib::unordered_set<NodeID> & nodesAvailable,
                                                         std::queue<std::vector<NodeID>> & queue) {
 
 
@@ -150,7 +149,7 @@ public:
     }
 
     void cutBFSStartNodes(graph_access &G,
-                          std::unordered_set<NodeID> & nodesAvailable,
+                          extlib::unordered_set<NodeID> & nodesAvailable,
                           std::queue<std::vector<NodeID>> & queue) {
         forall_nodes(G, n) {
             PartitionID partitionIDSource = G.getPartitionIndex(n);
@@ -176,7 +175,7 @@ public:
     }
 
     void gainBFSStartNodes(graph_access &G,
-                           std::unordered_set<NodeID> & nodesAvailable,
+                           extlib::unordered_set<NodeID> & nodesAvailable,
                            std::queue<std::vector<NodeID>> & queue,
                            int min_gain) {
         forall_nodes(G, n) {
@@ -197,7 +196,7 @@ public:
         return (6*m + 2*(EdgeID) n) * (EdgeID) k;
     }
 
-    size_t numEdgesBetweenNonStarters(graph_access & G, std::unordered_set<NodeID> & nodesAvailable) {
+    size_t numEdgesBetweenNonStarters(graph_access & G, extlib::unordered_set<NodeID> & nodesAvailable) {
 
         size_t m =0;
         std::vector<std::vector<bool>> edges_exist;
@@ -225,7 +224,7 @@ public:
         return m;
     }
 
-    size_t edgesInCoarse(graph_access & G, std::unordered_set<NodeID> & nodesAvailable,
+    size_t edgesInCoarse(graph_access & G, extlib::unordered_set<NodeID> & nodesAvailable,
                          NodeID q, std::vector<size_t> & degrees) {
         size_t m = 0;
         std::vector<bool> neighbors(G.get_partition_count(), false);

--- a/lib/ilp_improve/ilp_improve.h
+++ b/lib/ilp_improve/ilp_improve.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <unordered_set>
-#include <unordered_map>
 #include <queue>
 #include <vector>
 #include <algorithm>
@@ -21,10 +19,11 @@
 #include "partition/uncoarsening/refinement/cycle_improvements/cycle_refinement.h"
 #include "partition/coarsening/clustering/size_constraint_label_propagation.h"
 #include "partition/graph_partitioner.h"
+#include "definitions.h"
 
 class ilp_improve {
 public:
-    size_t computeBFS(graph_access &G, std::unordered_set<NodeID> &nodesAvailable,
+    size_t computeBFS(graph_access &G, extlib::unordered_set<NodeID> &nodesAvailable,
                     PartitionConfig partition_config, size_t limit_nonzeroes) {
         // BFS to get available nodes
         std::queue<std::vector<NodeID> > queue;
@@ -100,7 +99,7 @@ public:
                 for (NodeID el : equalGain) {
                     std::queue<std::vector<size_t> > bfs_queue;
                     bfs_queue.push(std::vector<size_t>(1,el));
-                    std::unordered_set<NodeID> inMyTree;
+                    extlib::unordered_set<NodeID> inMyTree;
                     nodesAvailable.emplace(el);
 
                     n++;
@@ -277,9 +276,9 @@ public:
     }
 
     PartitionID computeBlocks(graph_access &G,
-                              std::unordered_set<NodeID> &nodesAvailable, size_t k) {
+                              extlib::unordered_set<NodeID> &nodesAvailable, size_t k) {
         // create blocks
-        std::unordered_map<PartitionID, std::unordered_set<NodeID> > blocks;
+        extlib::unordered_map<PartitionID, extlib::unordered_set<NodeID> > blocks;
 
         std::vector<size_t> not_found(k, 0);
         forall_nodes(G, node) {
@@ -306,7 +305,7 @@ public:
     }
 
     void setPartitionIDs(graph_access &G,
-                         std::unordered_set<NodeID> &nodesAvailable,
+                         extlib::unordered_set<NodeID> &nodesAvailable,
                          PartitionID numBlocks) {
         PartitionID count = numBlocks;
         for (NodeID n: nodesAvailable) {
@@ -346,7 +345,7 @@ public:
         NodeID numEdges = coarser.number_of_edges() / 2;
 
         // create index for start edges of nodes
-        std::unordered_map<EdgeID, NodeID> edge_source;
+        extlib::unordered_map<EdgeID, NodeID> edge_source;
         forall_nodes(coarser, node) {
                     forall_out_edges(coarser, e, node) {
                                 edge_source[e] = node;

--- a/lib/mapping/communication_graph_search_space.h
+++ b/lib/mapping/communication_graph_search_space.h
@@ -13,6 +13,7 @@
 #include "data_structure/graph_access.h"
 #include "tools/random_functions.h"
 #include "partition_config.h"
+#include "definitions.h"
 
 extern int global_num_nodes;
 
@@ -114,7 +115,7 @@ class communication_graph_search_space {
 
         private:
                 std::vector< std::pair< NodeID, NodeID > > m_list_of_pairs;                 
-                std::unordered_map< std::pair< NodeID, NodeID>, bool > m_pair_active;                 
+                extlib::unordered_map< std::pair< NodeID, NodeID>, bool > m_pair_active;
                 std::vector< int > m_deepth;
                 int m_limit;
                 int m_pointer;

--- a/lib/node_ordering/min_degree_ordering.h
+++ b/lib/node_ordering/min_degree_ordering.h
@@ -17,7 +17,7 @@ class clique {
 
 public:
         // create a clique from a list of nodes
-        inline clique(std::unordered_set<NodeID> n = {}) : nodes(n) {};
+        inline clique(extlib::unordered_set<NodeID> n = {}) : nodes(n) {};
 
         // check if a node is part of this clique
         inline bool contains(NodeID node) const { 
@@ -40,7 +40,7 @@ public:
         }
 
         // remove node from this clique
-        inline std::unordered_set<NodeID>::const_iterator remove(NodeID node) {
+        inline extlib::unordered_set<NodeID>::const_iterator remove(NodeID node) {
                 auto it = nodes.find(node);
                 if (it != nodes.end()) {
                         return nodes.erase(it);
@@ -58,7 +58,7 @@ public:
         }
 
         // return the number of nodes in the clique
-        inline std::unordered_set<NodeID>::size_type size() const {
+        inline extlib::unordered_set<NodeID>::size_type size() const {
                 return nodes.size();
         }
 
@@ -67,16 +67,16 @@ public:
         }
 
         // iterators over the nodes in the clique
-        inline const std::unordered_set<NodeID>::const_iterator begin() const {
+        inline const extlib::unordered_set<NodeID>::const_iterator begin() const {
                 return nodes.cbegin();
         }
 
-        inline const std::unordered_set<NodeID>::const_iterator end() const {
+        inline const extlib::unordered_set<NodeID>::const_iterator end() const {
                 return nodes.cend();
         }
 
 private:
-        std::unordered_set<NodeID> nodes;
+        extlib::unordered_set<NodeID> nodes;
 
 };
 
@@ -108,7 +108,7 @@ private:
 
         // Nodes that haven't been eliminated
         // This is mainly used to eliminate nodes that are only members of one clique
-        std::unordered_set<NodeID> current_nodes;
+        extlib::unordered_set<NodeID> current_nodes;
 
         // This "clique" tracks all neighbors of eliminated nodes that are still in the graph
         // It's not actually a clique, but the clique-class is useful here

--- a/lib/node_ordering/reductions.cpp
+++ b/lib/node_ordering/reductions.cpp
@@ -7,7 +7,6 @@
 #include <functional>
 #include <memory>
 #include <queue>
-#include <unordered_set>
 #include <utility>
 
 #include "data_structure/priority_queues/bucket_pq.h"
@@ -15,8 +14,9 @@
 #include "node_ordering/reductions.h"
 #include "tools/macros_assertions.h"
 #include "tools/timer.h"
-
 #include "io/graph_io.h"
+#include "definitions.h"
+
 
 /******************************/
 /* NODE CONTRACTION FUNCTIONS */
@@ -31,7 +31,7 @@
 //  - 'mapping':                mapping from nodes in 'graph_after' to nodes in 'graph_before'
 void contract_nodes(graph_access &graph_before, graph_access &graph_after,
                     const std::vector<std::vector<NodeID>> &node_groups,
-                    std::unordered_map<NodeID, std::vector<NodeID>> &mapping) {
+                    extlib::unordered_map<NodeID, std::vector<NodeID>> &mapping) {
         graph_after.start_construction(node_groups.size(), graph_before.number_of_edges());
 
         std::vector<NodeID> reverse_map(graph_before.number_of_nodes(), 0);

--- a/lib/node_ordering/reductions.h
+++ b/lib/node_ordering/reductions.h
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <iomanip>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 #include "data_structure/graph_access.h"
@@ -198,7 +197,7 @@ public:
 
 protected:
         // Mapping from the reduced graph to groups of nodes in the original graph
-        std::unordered_map<NodeID, std::vector<NodeID>> mapping;
+        extlib::unordered_map<NodeID, std::vector<NodeID>> mapping;
 
 };
 
@@ -259,7 +258,7 @@ public:
 
 protected:
         // We reverse paths and parts of paths in the map function, so we make the mapping mutable for this reduction
-        mutable std::unordered_map<NodeID, std::vector<NodeID>> mapping;
+        mutable extlib::unordered_map<NodeID, std::vector<NodeID>> mapping;
 
 };
 

--- a/lib/parallel_mh/galinier_combine/gal_combine.cpp
+++ b/lib/parallel_mh/galinier_combine/gal_combine.cpp
@@ -17,6 +17,7 @@
 #include "uncoarsening/refinement/mixed_refinement.h"
 #include "uncoarsening/refinement/refinement.h"
 #include "uncoarsening/refinement/tabu_search/tabu_search.h"
+#include "definitions.h"
 
 gal_combine::gal_combine() {
                 
@@ -33,7 +34,7 @@ gal_combine::~gal_combine() {
 // apply our refinements and tabu search
 void gal_combine::perform_gal_combine( PartitionConfig & config, graph_access & G) {
         //first greedily compute a matching of the partitions
-        std::vector< std::unordered_map<PartitionID, unsigned> > counters(config.k);
+        std::vector< extlib::unordered_map<PartitionID, unsigned> > counters(config.k);
         forall_nodes(G, node) {
                 //boundary_pair bp;
                 if(counters[G.getPartitionIndex(node)].find(G.getSecondPartitionIndex(node)) != counters[G.getPartitionIndex(node)].end()) {
@@ -56,7 +57,7 @@ void gal_combine::perform_gal_combine( PartitionConfig & config, graph_access & 
                 PartitionID best_unassigned = config.k;
                 NodeWeight  best_value      = 0;
 
-                for( std::unordered_map<PartitionID, unsigned>::iterator it = counters[cur_partition].begin(); 
+                for( extlib::unordered_map<PartitionID, unsigned>::iterator it = counters[cur_partition].begin();
                      it != counters[cur_partition].end(); ++it) {
                         if( rhs_matched[it->first] == false && it->second > best_value ) {
                                 best_unassigned = it->first; 

--- a/lib/partition/coarsening/clustering/size_constraint_label_propagation.cpp
+++ b/lib/partition/coarsening/clustering/size_constraint_label_propagation.cpp
@@ -5,9 +5,6 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-
-#include <unordered_map>
-
 #include <sstream>
 #include "../edge_rating/edge_ratings.h"
 #include "../matching/gpa/gpa_matching.h"
@@ -18,6 +15,7 @@
 #include "tools/quality_metrics.h"
 #include "tools/random_functions.h"
 #include "io/graph_io.h"
+#include "definitions.h"
 
 #include "size_constraint_label_propagation.h"
 
@@ -65,9 +63,7 @@ void size_constraint_label_propagation::ensemble_two_clusterings( graph_access &
                                                                   std::vector<NodeID> & rhs, 
                                                                   std::vector< NodeID > & output,
                                                                   NodeID & no_of_coarse_vertices) {
-
-
-        hash_ensemble new_mapping; 
+        extlib::unordered_map_with_custom_hash_and_comparator<ensemble_pair, data_ensemble_pair, hash_ensemble_pair, compare_ensemble_pair> new_mapping;
         no_of_coarse_vertices = 0;
         for( NodeID node = 0; node < lhs.size(); node++) {
                 ensemble_pair cur_pair;
@@ -76,7 +72,8 @@ void size_constraint_label_propagation::ensemble_two_clusterings( graph_access &
                 cur_pair.n   = G.number_of_nodes(); 
 
                 if(new_mapping.find(cur_pair) == new_mapping.end() ) {
-                        new_mapping[cur_pair].mapping = no_of_coarse_vertices;
+                        auto& value = new_mapping[cur_pair];
+                        value.mapping = no_of_coarse_vertices;
                         no_of_coarse_vertices++;
                 }
 
@@ -210,7 +207,7 @@ void size_constraint_label_propagation::remap_cluster_ids(const PartitionConfig 
                                                           NodeID & no_of_coarse_vertices, bool apply_to_graph) {
 
         PartitionID cur_no_clusters = 0;
-        std::unordered_map<PartitionID, PartitionID> remap;
+        extlib::unordered_map<PartitionID, PartitionID> remap;
         forall_nodes(G, node) {
                 PartitionID cur_cluster = cluster_id[node];
                 //check wether we already had that

--- a/lib/partition/coarsening/clustering/size_constraint_label_propagation.h
+++ b/lib/partition/coarsening/clustering/size_constraint_label_propagation.h
@@ -18,31 +18,22 @@ struct ensemble_pair {
 };
 
 struct compare_ensemble_pair {
-        bool operator()(const ensemble_pair pair_a, const ensemble_pair pair_b) const {
-                bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
-                return eq;
+        bool operator()(const ensemble_pair& pair_a, const ensemble_pair& pair_b) const {
+                return pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs;
         }
 };
 
-struct hash_ensemble_pair{
-       size_t operator()(const ensemble_pair pair) const {
+struct hash_ensemble_pair {
+       size_t operator()(const ensemble_pair& pair) const {
                 return pair.lhs*pair.n + pair.rhs;
        }
 };
 
 struct data_ensemble_pair {
         NodeID mapping;
-
-        data_ensemble_pair() {
-                mapping = 0;
+        data_ensemble_pair() : mapping(0) {
         }
 };
-
-typedef std::unordered_map<const ensemble_pair, 
-                                data_ensemble_pair, 
-                                hash_ensemble_pair, 
-                                compare_ensemble_pair> hash_ensemble;
-
 
 class size_constraint_label_propagation : public matching {
         public:

--- a/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph.h
+++ b/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph.h
@@ -9,7 +9,6 @@
 #define AUGMENTED_QUOTIENT_GRAPH_E5ZEJUBV
 
 #include <algorithm>
-#include <unordered_map>
 #include <vector>
 
 #include "definitions.h"
@@ -53,7 +52,7 @@ struct block_pair_difference {
         }
 };
 
-typedef std::unordered_map<const boundary_pair, set_pairwise_local_searches, hash_boundary_pair_directed, compare_boundary_pair_directed> augmented_Qgraph_internal;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, set_pairwise_local_searches, hash_boundary_pair_directed, compare_boundary_pair_directed> augmented_Qgraph_internal;
 
 class augmented_Qgraph {
 public:
@@ -82,7 +81,7 @@ public:
         int get_max_vertex_weight_difference() { return m_max_vertex_weight_difference; };
 
 private:
-        augmented_Qgraph_internal m_aqg;
+        extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, set_pairwise_local_searches, hash_boundary_pair_directed, compare_boundary_pair_directed> m_aqg;
         int m_max_vertex_weight_difference;
 };
 

--- a/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
+++ b/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
@@ -16,6 +16,7 @@
 #include "uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h"
 #include "uncoarsening/refinement/kway_graph_refinement/kway_stop_rule.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h"
+#include "definitions.h"
 
 augmented_Qgraph_fabric::augmented_Qgraph_fabric() {
 }
@@ -183,7 +184,7 @@ bool augmented_Qgraph_fabric::build_augmented_quotient_graph( PartitionConfig & 
                         } // else
 
                         start_block = cur_block;
-                        std::unordered_map< PartitionID, bool > allready_performed_local_search;
+                        extlib::unordered_map< PartitionID, bool > allready_performed_local_search;
 
                         while( boundary.getBlockWeight( cur_block ) <= config.upper_bound_partition ) {
                                 boundary_pair bp;

--- a/lib/partition/uncoarsening/refinement/cycle_improvements/cycle_definitions.h
+++ b/lib/partition/uncoarsening/refinement/cycle_improvements/cycle_definitions.h
@@ -8,8 +8,6 @@
 #ifndef CYCLE_DEFINITIONS_4GQMW8PZ
 #define CYCLE_DEFINITIONS_4GQMW8PZ
 
-#include <unordered_map>
-
 #include "uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h"
 
 struct undo_struct {
@@ -27,7 +25,7 @@ struct data_qgraph_edge {
         }
 };
 
-typedef std::unordered_map<const boundary_pair, data_qgraph_edge, hash_boundary_pair_directed, compare_boundary_pair_directed> edge_movements;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, data_qgraph_edge, hash_boundary_pair_directed, compare_boundary_pair_directed> edge_movements;
 
 
 #endif /* end of include guard: DEFINITIONS_4GQMW8PZ */

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.cpp
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.cpp
@@ -6,13 +6,14 @@
  *****************************************************************************/
 
 #include <algorithm>
-#include <unordered_map>
+// #include <unordered_map>
 
 #include "kway_graph_refinement.h"
 #include "kway_graph_refinement_core.h"
 #include "kway_stop_rule.h"
 #include "quality_metrics.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 kway_graph_refinement::kway_graph_refinement() {
 }
@@ -61,7 +62,7 @@ void kway_graph_refinement::setup_start_nodes(PartitionConfig & config, graph_ac
         QuotientGraphEdges quotient_graph_edges;
         boundary.getQuotientGraphEdges(quotient_graph_edges);
 
-        std::unordered_map<NodeID, bool> allready_contained;
+        extlib::unordered_map<NodeID, bool> allready_contained;
 
         for( unsigned i = 0; i < quotient_graph_edges.size(); i++) {
                 boundary_pair & ret_value = quotient_graph_edges[i];
@@ -71,7 +72,7 @@ void kway_graph_refinement::setup_start_nodes(PartitionConfig & config, graph_ac
                 PartialBoundary & partial_boundary_lhs = boundary.getDirectedBoundary(lhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_lhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), lhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -80,7 +81,7 @@ void kway_graph_refinement::setup_start_nodes(PartitionConfig & config, graph_ac
                 PartialBoundary & partial_boundary_rhs = boundary.getDirectedBoundary(rhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_rhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), rhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
@@ -13,6 +13,7 @@
 #include "kway_stop_rule.h"
 #include "quality_metrics.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 kway_graph_refinement_core::kway_graph_refinement_core() : commons (NULL){
 }
@@ -26,7 +27,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round(PartitionCon
                                                                     boundary_starting_nodes & start_nodes, 
                                                                     int step_limit, 
                                                                     vertex_moved_hashtable & moved_idx) {
-        std::unordered_map<PartitionID, PartitionID> touched_blocks;
+        extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
         return single_kway_refinement_round_internal(config, G, boundary, start_nodes, 
                                                      step_limit, moved_idx, false, touched_blocks);
 }
@@ -37,7 +38,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round(PartitionCon
                                                                     boundary_starting_nodes & start_nodes, 
                                                                     int step_limit, 
                                                                     vertex_moved_hashtable & moved_idx,
-                                                                    std::unordered_map<PartitionID, PartitionID> & touched_blocks) {
+                                                                    extlib::unordered_map<PartitionID, PartitionID> & touched_blocks) {
 
         return single_kway_refinement_round_internal(config, G, boundary, start_nodes, 
                                                      step_limit, moved_idx, true, touched_blocks);
@@ -45,13 +46,13 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round(PartitionCon
 
 
 EdgeWeight kway_graph_refinement_core::single_kway_refinement_round_internal(PartitionConfig & config, 
-                                                                    graph_access & G, 
+                                                                    graph_access & G,
                                                                     complete_boundary & boundary, 
                                                                     boundary_starting_nodes & start_nodes, 
                                                                     int step_limit,
                                                                     vertex_moved_hashtable & moved_idx,
                                                                     bool compute_touched_partitions,
-                                                                    std::unordered_map<PartitionID, PartitionID> &  touched_blocks) {
+                                                                    extlib::unordered_map<PartitionID, PartitionID> &  touched_blocks) {
 
         if( commons == NULL ) commons = new kway_graph_refinement_commons(config);
 

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h
@@ -8,7 +8,6 @@
 #ifndef KWAY_GRAPH_REFINEMENT_CORE_PVGY97EW
 #define KWAY_GRAPH_REFINEMENT_CORE_PVGY97EW
 
-#include <unordered_map>
 #include <vector>
 
 #include "data_structure/priority_queues/priority_queue_interface.h"
@@ -17,6 +16,7 @@
 #include "tools/random_functions.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h"
 #include "uncoarsening/refinement/refinement.h"
+#include "definitions.h"
 
 class kway_graph_refinement_core  {
         public:
@@ -36,7 +36,7 @@ class kway_graph_refinement_core  {
                                                         boundary_starting_nodes & start_nodes, 
                                                         int step_limit, 
                                                         vertex_moved_hashtable & moved_idx,
-                                                        std::unordered_map<PartitionID, PartitionID> & touched_blocks); 
+                                                        extlib::unordered_map<PartitionID, PartitionID> & touched_blocks);
 
 
          private:
@@ -47,7 +47,7 @@ class kway_graph_refinement_core  {
                                                                 int step_limit,
                                                                 vertex_moved_hashtable & moved_idx,
                                                                 bool compute_touched_partitions,
-                                                                std::unordered_map<PartitionID, PartitionID> &  touched_blocks); 
+                                                                extlib::unordered_map<PartitionID, PartitionID> &  touched_blocks);
 
 
                 void init_queue_with_boundary(const PartitionConfig & config, 

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.cpp
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.cpp
@@ -6,7 +6,6 @@
  *****************************************************************************/
 
 #include <algorithm>
-#include <unordered_map>
 
 #include "kway_graph_refinement_core.h"
 #include "kway_stop_rule.h"
@@ -14,6 +13,7 @@
 #include "quality_metrics.h"
 #include "random_functions.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h"
+#include "definitions.h"
 
 multitry_kway_fm::multitry_kway_fm() {
         commons = NULL;
@@ -49,7 +49,7 @@ int multitry_kway_fm::perform_refinement(PartitionConfig & config, graph_access 
                         todolist.push_back(start_nodes[i]);
                 }
 
-                std::unordered_map<PartitionID, PartitionID> touched_blocks;
+                extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
                 EdgeWeight improvement = start_more_locallized_search(config, G,  boundary, 
                                                                       init_neighbors, false, touched_blocks, 
                                                                       todolist);
@@ -71,7 +71,7 @@ int multitry_kway_fm::perform_refinement_around_parts(PartitionConfig & config, 
                                                       complete_boundary & boundary, bool init_neighbors, 
                                                       unsigned alpha, 
                                                       PartitionID & lhs, PartitionID & rhs, 
-                                                      std::unordered_map<PartitionID, PartitionID> & touched_blocks) {
+                                                      extlib::unordered_map<PartitionID, PartitionID> & touched_blocks) {
         if( commons == NULL ) commons = new kway_graph_refinement_commons(config);
 
         unsigned tmp_alpha                = config.kway_adaptive_limits_alpha;
@@ -109,7 +109,7 @@ int multitry_kway_fm::perform_refinement_around_parts(PartitionConfig & config, 
 int multitry_kway_fm::start_more_locallized_search(PartitionConfig & config, graph_access & G, 
                                                    complete_boundary & boundary, bool init_neighbors, 
                                                    bool compute_touched_blocks, 
-                                                   std::unordered_map<PartitionID, PartitionID> & touched_blocks, 
+                                                   extlib::unordered_map<PartitionID, PartitionID> & touched_blocks,
                                                    std::vector<NodeID> & todolist) {
 
         random_functions::permutate_vector_good(todolist, false);

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.h
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.h
@@ -27,7 +27,7 @@ class multitry_kway_fm {
                                                     complete_boundary & boundary, bool init_neighbors, 
                                                     unsigned alpha, 
                                                     PartitionID & lhs, PartitionID & rhs,
-                                                    std::unordered_map<PartitionID, PartitionID> & touched_blocks);
+                                                    extlib::unordered_map<PartitionID, PartitionID> & touched_blocks);
 
 
         private:
@@ -35,7 +35,7 @@ class multitry_kway_fm {
                                                  complete_boundary & boundary, 
                                                  bool init_neighbors, 
                                                  bool compute_touched_blocks, 
-                                                 std::unordered_map<PartitionID, PartitionID> & touched_blocks, 
+                                                 extlib::unordered_map<PartitionID, PartitionID> & touched_blocks,
                                                  std::vector<NodeID> & todolist);
 
                 kway_graph_refinement_commons* commons;

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h
@@ -8,8 +8,6 @@
 #ifndef VMOVEDHT_4563r97820954
 #define VMOVEDHT_4563r97820954
 
-#include <unordered_map>
-
 #include "definitions.h"
 #include "limits.h"
 
@@ -36,6 +34,6 @@ struct hash_nodes {
        }
 };
 
-typedef std::unordered_map<const NodeID, moved_index, hash_nodes, compare_nodes> vertex_moved_hashtable;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<NodeID, moved_index, hash_nodes, compare_nodes> vertex_moved_hashtable;
 
 #endif

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/boundary_lookup.h
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/boundary_lookup.h
@@ -8,11 +8,11 @@
 #ifndef BOUNDARY_LOOKUP_2JMSKBSI
 #define BOUNDARY_LOOKUP_2JMSKBSI
 
-#include <unordered_map>
-
 #include "definitions.h"
 #include "limits.h"
 #include "partial_boundary.h"
+
+// TODO: do some cleanup here.
 
 struct boundary_pair {
         PartitionID k;
@@ -20,9 +20,8 @@ struct boundary_pair {
         PartitionID rhs;
 };
 
-
 struct compare_boundary_pair {
-        bool operator()(const boundary_pair pair_a, const boundary_pair pair_b) const {
+        bool operator()(const boundary_pair& pair_a, const boundary_pair& pair_b) const {
                 bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
                      eq = eq || (pair_a.lhs == pair_b.rhs && pair_a.rhs == pair_b.lhs); 
                 return eq;
@@ -30,9 +29,8 @@ struct compare_boundary_pair {
 };
 
 struct compare_boundary_pair_directed {
-        bool operator()(const boundary_pair pair_a, const boundary_pair pair_b) const {
-                bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
-                return eq;
+        bool operator()(const boundary_pair& pair_a, const boundary_pair& pair_b) const {
+                return pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs;
         }
 };
 
@@ -45,30 +43,31 @@ struct data_boundary_pair {
 
         bool initialized;
 
-        data_boundary_pair() {
-                edge_cut = 0;
-                lhs = std::numeric_limits<PartitionID>::max();
-                rhs = std::numeric_limits<PartitionID>::max();
-                initialized = false;
+        data_boundary_pair()
+        : lhs(std::numeric_limits<PartitionID>::max())
+        , rhs(std::numeric_limits<PartitionID>::max())
+        , edge_cut(0)
+        , initialized(false)
+        {
         }
 };
 
-struct hash_boundary_pair_directed{
-       size_t operator()(const boundary_pair pair) const {
+struct hash_boundary_pair_directed {
+       size_t operator()(const boundary_pair& pair) const {
                 return pair.lhs*pair.k + pair.rhs;
        }
 };
 
-struct hash_boundary_pair{
-       size_t operator()(const boundary_pair pair) const {
-                if(pair.lhs < pair.rhs) 
+struct hash_boundary_pair {
+       size_t operator()(const boundary_pair& pair) const {
+                if (pair.lhs < pair.rhs)
                         return pair.lhs*pair.k + pair.rhs;
                 else 
                         return pair.rhs*pair.k + pair.lhs;
        }
 };
 
-typedef std::unordered_map<const boundary_pair, data_boundary_pair, hash_boundary_pair, compare_boundary_pair> block_pairs;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, data_boundary_pair, hash_boundary_pair, compare_boundary_pair> block_pairs;
 
 
 

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h
@@ -9,13 +9,13 @@
 #define COMPLETE_BOUNDARY_URZZFDEI
 
 #include <execinfo.h>
-#include <unordered_map>
 #include <utility>
 
 #include "boundary_lookup.h"
 #include "data_structure/graph_access.h"
 #include "partial_boundary.h"
 #include "partition_config.h"
+#include "definitions.h"
 
 struct block_informations {
         NodeWeight block_weight;
@@ -135,12 +135,11 @@ inline void complete_boundary::build() {
                 } endfor
         } endfor
 
-        block_pairs::iterator iter; 
-        for(iter = m_pairs.begin(); iter != m_pairs.end(); iter++ ) { 
-                data_boundary_pair& value = iter->second;
-                value.edge_cut /= 2;
+        for (auto it = m_pairs.begin(); it != m_pairs.end(); ++it)
+        {
+            auto& tmp = it.value();
+            tmp.edge_cut /= 2;
         }
-
 }
 
 inline void complete_boundary::build_from_coarser(complete_boundary * coarser_boundary, 
@@ -206,10 +205,10 @@ inline void complete_boundary::build_from_coarser(complete_boundary * coarser_bo
                 setBlockWeight(p, coarser_boundary->getBlockWeight(p));
         }
 
-        block_pairs::iterator iter; 
-        for(iter = m_pairs.begin(); iter != m_pairs.end(); iter++ ) { 
-                data_boundary_pair& value = iter->second;
-                value.edge_cut /= 2;
+        for (auto it = m_pairs.begin(); it != m_pairs.end(); ++it)
+        {
+            auto& tmp = it.value();
+            tmp.edge_cut /= 2;
         }
 }
 
@@ -425,20 +424,20 @@ inline void complete_boundary::getNeighbors(PartitionID & block, std::vector<Par
 void complete_boundary::setup_start_nodes_around_blocks(graph_access & G, 
                                                         PartitionID & lhs, PartitionID & rhs, 
                                                         boundary_starting_nodes & start_nodes) {
-
         std::vector<PartitionID> lhs_neighbors;
         getNeighbors(lhs, lhs_neighbors);
 
         std::vector<PartitionID> rhs_neighbors;
         getNeighbors(rhs, rhs_neighbors);
 
-        std::unordered_map<NodeID, bool> allready_contained;
+        extlib::unordered_map<NodeID, bool> allready_contained;
+
         for( unsigned i = 0; i < lhs_neighbors.size(); i++) {
                 PartitionID neighbor = lhs_neighbors[i];
                 PartialBoundary & partial_boundary_lhs = getDirectedBoundary(lhs, lhs, neighbor);
                 forall_boundary_nodes(partial_boundary_lhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), lhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -447,7 +446,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_neighbor = getDirectedBoundary(neighbor, lhs, neighbor);
                 forall_boundary_nodes(partial_boundary_neighbor, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), neighbor);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -459,7 +458,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_rhs = getDirectedBoundary(rhs, rhs, neighbor);
                 forall_boundary_nodes(partial_boundary_rhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), rhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -468,7 +467,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_neighbor = getDirectedBoundary(neighbor, rhs, neighbor);
                 forall_boundary_nodes(partial_boundary_neighbor, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), neighbor);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -477,12 +476,13 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
 }
 
 
-void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_starting_nodes & start_nodes) {
+void complete_boundary::setup_start_nodes_all(graph_access & G,
+                                              boundary_starting_nodes & start_nodes) {
         QuotientGraphEdges quotient_graph_edges;
         getQuotientGraphEdges(quotient_graph_edges);
 
-        std::unordered_map<NodeID, bool> allready_contained;
-        
+        extlib::unordered_map<NodeID, bool> allready_contained;
+
         for( unsigned i = 0; i < quotient_graph_edges.size(); i++) {
                 boundary_pair & ret_value = quotient_graph_edges[i];
                 PartitionID lhs = ret_value.lhs; 
@@ -491,7 +491,7 @@ void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_startin
                 PartialBoundary & partial_boundary_lhs = getDirectedBoundary(lhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_lhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), lhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -500,7 +500,7 @@ void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_startin
                 PartialBoundary & partial_boundary_rhs = getDirectedBoundary(rhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_rhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), rhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/cut_flow_problem_solver.cpp
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/cut_flow_problem_solver.cpp
@@ -10,15 +10,13 @@
 #include <map>
 #include <math.h>
 #include <sstream>
-#include <unordered_map>
 
 #include "algorithms/push_relabel.h"
 #include "cut_flow_problem_solver.h"
 #include "most_balanced_minimum_cuts/most_balanced_minimum_cuts.h"
 #include "data_structure/flow_graph.h"
 #include "io/graph_io.h"
-
-
+#include "definitions.h"
 
 cut_flow_problem_solver::cut_flow_problem_solver() {
 }
@@ -75,7 +73,7 @@ EdgeWeight cut_flow_problem_solver::convert_ds( const PartitionConfig & config,
         //building up the graph as in parse.h of hi_pr code
         NodeID idx = 0;
         new_to_old_ids.resize(lhs_boundary_stripe.size() + rhs_boundary_stripe.size());
-        std::unordered_map<NodeID, NodeID> old_to_new;
+        extlib::unordered_map<NodeID, NodeID> old_to_new;
         for( unsigned i = 0; i < lhs_boundary_stripe.size(); i++) {
                 G.setPartitionIndex(lhs_boundary_stripe[i], BOUNDARY_STRIPE_NODE);
                 new_to_old_ids[idx]                = lhs_boundary_stripe[i];

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/most_balanced_minimum_cuts/most_balanced_minimum_cuts.cpp
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/most_balanced_minimum_cuts/most_balanced_minimum_cuts.cpp
@@ -170,7 +170,7 @@ void most_balanced_minimum_cuts::build_internal_scc_graph( graph_access & residu
         scc_graph.start_construction(comp_count, edge_count);
         for( unsigned i = 0; i < (unsigned) comp_count; i++) {
                 NodeID node = scc_graph.new_node();
-                std::unordered_map<NodeID, bool> allready_contained;
+                extlib::unordered_map<NodeID, bool> allready_contained;
                 for(unsigned j = 0; j < edges[i].size(); j++) {
                         if(allready_contained.find(edges[i][j]) == allready_contained.end()) {
                                 scc_graph.new_edge(node, edges[i][j]);

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/partial_boundary.h
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/partial_boundary.h
@@ -8,31 +8,27 @@
 #ifndef PARTIAL_BOUNDARY_963CRO9F_
 #define PARTIAL_BOUNDARY_963CRO9F_
 
-#include <unordered_map>
 #include "definitions.h"
 
 struct compare_nodes_contains {
-        bool operator()(const NodeID lhs, const NodeID rhs) const {
-                return (lhs == rhs);
+        bool operator()(const NodeID& lhs, const NodeID& rhs) const {
+                return lhs == rhs;
         }
 };
 
-
 struct is_boundary {
        bool contains;
-       is_boundary() {
-                contains = false;
+       is_boundary() : contains(false) {
        }
 };
 
-
 struct hash_boundary_nodes {
-       size_t operator()(const NodeID idx) const {
+       size_t operator()(const NodeID& idx) const {
                 return idx;
        }
 };
 
-typedef std::unordered_map<const NodeID, is_boundary, hash_boundary_nodes, compare_nodes_contains> is_boundary_node_hashtable;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<NodeID, is_boundary, hash_boundary_nodes, compare_nodes_contains> is_boundary_node_hashtable;
 
 class PartialBoundary {
         public:

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_refinement.cpp
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_refinement.cpp
@@ -5,8 +5,6 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-#include <unordered_map>
-
 #include "2way_fm_refinement/two_way_fm.h"
 #include "complete_boundary.h"
 #include "flow_refinement/two_way_flow_refinement.h"
@@ -107,7 +105,7 @@ EdgeWeight quotient_graph_refinement::perform_refinement(PartitionConfig & confi
                 EdgeWeight multitry_improvement = 0;
                 if(config.refinement_scheduling_algorithm == REFINEMENT_SCHEDULING_ACTIVE_BLOCKS_REF_KWAY ) {
                         multitry_kway_fm kway_ref;
-                        std::unordered_map<PartitionID, PartitionID> touched_blocks;
+                        extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
 
                         multitry_improvement = kway_ref.perform_refinement_around_parts(cfg, G, 
                                                                                 boundary, true, 

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/active_block_quotient_graph_scheduler.h
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/active_block_quotient_graph_scheduler.h
@@ -8,11 +8,10 @@
 #ifndef ACTIVE_BLOCK_QUOTIENT_GRAPH_SCHEDULER_2QATIGSY
 #define ACTIVE_BLOCK_QUOTIENT_GRAPH_SCHEDULER_2QATIGSY
 
-#include <unordered_map>
-
 #include "partition_config.h"
 #include "quotient_graph_scheduling.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 class active_block_quotient_graph_scheduler : public quotient_graph_scheduling {
         public:
@@ -27,7 +26,7 @@ class active_block_quotient_graph_scheduler : public quotient_graph_scheduling {
                 virtual void pushStatistics(qgraph_edge_statistics & statistic);
                 virtual void init();
 
-                void activate_blocks(std::unordered_map<PartitionID, PartitionID> & blocks);
+                void activate_blocks(extlib::unordered_map<PartitionID, PartitionID> & blocks);
 
         private: 
                 QuotientGraphEdges & m_quotient_graph_edges;
@@ -81,8 +80,8 @@ inline void active_block_quotient_graph_scheduler::pushStatistics(qgraph_edge_st
         }
 }
 
-inline void active_block_quotient_graph_scheduler::activate_blocks(std::unordered_map<PartitionID, PartitionID> & blocks) {
-        std::unordered_map<PartitionID, PartitionID>::iterator it;
+inline void active_block_quotient_graph_scheduler::activate_blocks(extlib::unordered_map<PartitionID, PartitionID> & blocks) {
+        extlib::unordered_map<PartitionID, PartitionID>::iterator it;
         for(it = blocks.begin(); it != blocks.end(); ++it) {
              m_is_block_active[it->first] = true;
         }

--- a/lib/partition/uncoarsening/separator/vertex_separator_algorithm.cpp
+++ b/lib/partition/uncoarsening/separator/vertex_separator_algorithm.cpp
@@ -19,6 +19,7 @@
 #include "uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/simple_quotient_graph_scheduler.h"
 #include "vertex_separator_algorithm.h"
 #include "vertex_separator_flow_solver.h"
+#include "definitions.h"
 
 vertex_separator_algorithm::vertex_separator_algorithm() {
 
@@ -107,7 +108,7 @@ void vertex_separator_algorithm::build_flow_problem(const PartitionConfig & conf
         NodeID n = 2*(lhs_nodes.size() + rhs_nodes.size() + separator_nodes.size()) + 2; // source and sink
 
         // find forward and backward mapping
-        std::unordered_map< NodeID, NodeID > backward_mapping;
+        extlib::unordered_map< NodeID, NodeID > backward_mapping;
         forward_mapping.clear();
         forward_mapping.resize(n-2);
 
@@ -488,7 +489,7 @@ NodeWeight vertex_separator_algorithm::improve_vertex_separator_internal(const P
         } endfor
 
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> allready_separator;
         for( unsigned int i = 0; i < output_separator.size(); i++) {
                 allready_separator[output_separator[i]] = true;
         }
@@ -507,7 +508,7 @@ void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig 
         PartitionConfig cfg     = config;
         cfg.bank_account_factor = 1;
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> allready_separator;
 
         QuotientGraphEdges qgraph_edges;
         boundary.getQuotientGraphEdges(qgraph_edges);
@@ -553,7 +554,7 @@ void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig 
 
 
         // now print the computed vertex separator to disk
-        std::unordered_map<NodeID, bool>::iterator it;
+        extlib::unordered_map<NodeID, bool>::iterator it;
         for( it = allready_separator.begin(); it != allready_separator.end(); ++it) {
                 overall_separator.push_back(it->first);
                 G.setPartitionIndex(it->first, G.getSeparatorBlock());
@@ -595,7 +596,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simpler(const Partitio
 
         quotient_graph_scheduling* scheduler = new simple_quotient_graph_scheduler(cfg, qgraph_edges,qgraph_edges.size()); 
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> allready_separator;
         do {
                 boundary_pair & bp = scheduler->getNext();
                 PartitionID lhs = bp.lhs;
@@ -622,7 +623,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simpler(const Partitio
         } while(!scheduler->hasFinished());
 
         // now print the computed vertex separator to disk
-        std::unordered_map<NodeID, bool>::iterator it;
+        extlib::unordered_map<NodeID, bool>::iterator it;
         for( it = allready_separator.begin(); it != allready_separator.end(); ++it) {
                 overall_separator.push_back(it->first);
                 G.setPartitionIndex(it->first, G.getSeparatorBlock());
@@ -649,7 +650,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
 
         quotient_graph_scheduling* scheduler = new simple_quotient_graph_scheduler(cfg, qgraph_edges,qgraph_edges.size()); 
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> allready_separator;
         do {
                 boundary_pair & bp = scheduler->getNext();
                 PartitionID lhs = bp.lhs;
@@ -679,7 +680,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
         } while(!scheduler->hasFinished());
 
         // now print the computed vertex separator to disk
-        std::unordered_map<NodeID, bool>::iterator it;
+        extlib::unordered_map<NodeID, bool>::iterator it;
         for( it = allready_separator.begin(); it != allready_separator.end(); ++it) {
                 overall_separator.push_back(it->first);
                 G.setPartitionIndex(it->first, G.getSeparatorBlock());
@@ -690,7 +691,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
 
 
 
-bool vertex_separator_algorithm::is_vertex_separator(graph_access & G, std::unordered_map<NodeID, bool> & separator) {
+bool vertex_separator_algorithm::is_vertex_separator(graph_access & G, extlib::unordered_map<NodeID, bool> & separator) {
          forall_nodes(G, node) {
                 forall_out_edges(G, e, node) {
                         NodeID target = G.getEdgeTarget(e);

--- a/lib/partition/uncoarsening/separator/vertex_separator_algorithm.h
+++ b/lib/partition/uncoarsening/separator/vertex_separator_algorithm.h
@@ -9,12 +9,11 @@
 #ifndef VERTEX_SEPARTATOR_ALGORITHM_XUDNZZM8
 #define VERTEX_SEPARTATOR_ALGORITHM_XUDNZZM8
 
-#include <unordered_map>
-
 #include "data_structure/graph_access.h"
 #include "data_structure/flow_graph.h"
 #include "partition_config.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h"
+#include "definitions.h"
 
 class vertex_separator_algorithm {
         public:
@@ -83,7 +82,7 @@ class vertex_separator_algorithm {
                                     std::vector< NodeID > & rhs_nodes,
                                     std::vector< NodeID > & separator);
                 //ASSERTIONS
-                bool is_vertex_separator(graph_access & G, std::unordered_map<NodeID, bool> & separator);
+                bool is_vertex_separator(graph_access & G, extlib::unordered_map<NodeID, bool> & separator);
 
 };
 

--- a/lib/partition/uncoarsening/separator/vertex_separator_flow_solver.cpp
+++ b/lib/partition/uncoarsening/separator/vertex_separator_flow_solver.cpp
@@ -8,11 +8,11 @@
 #include <algorithm>
 #include <map>
 #include <math.h>
-#include <unordered_map>
 
 #include "algorithms/push_relabel.h"
 #include "data_structure/flow_graph.h"
 #include "vertex_separator_flow_solver.h"
+#include "definitions.h"
 
 vertex_separator_flow_solver::vertex_separator_flow_solver() {
 
@@ -94,7 +94,7 @@ bool vertex_separator_flow_solver::build_flow_pb( const PartitionConfig & config
         //build mappings from old to new node ids and reverse
         NodeID idx = 0;
         new_to_old_ids.resize(lhs_nodes.size() + rhs_nodes.size());
-        std::unordered_map<NodeID, NodeID> old_to_new;
+        extlib::unordered_map<NodeID, NodeID> old_to_new;
         for( unsigned i = 0; i < lhs_nodes.size(); i++) {
                 new_to_old_ids[idx] = lhs_nodes[i];
                 old_to_new[lhs_nodes[i]] = idx++ ;

--- a/lib/partition/w_cycles/wcycle_partitioner.h
+++ b/lib/partition/w_cycles/wcycle_partitioner.h
@@ -13,6 +13,7 @@
 #include "data_structure/graph_access.h"
 #include "partition_config.h"
 #include "uncoarsening/refinement/refinement.h"
+#include "definitions.h"
 
 class wcycle_partitioner {
         public:
@@ -30,7 +31,7 @@ class wcycle_partitioner {
                 unsigned   m_deepest_level;
                 stop_rule* m_coarsening_stop_rule;
 
-                std::unordered_map<unsigned, bool> m_have_been_level_down;
+                extlib::unordered_map<unsigned, bool> m_have_been_level_down;
 };
 
 #endif /* end of include guard: WCYCLE_PARTITIONER_EPNDQMK */

--- a/lib/tools/graph_extractor.cpp
+++ b/lib/tools/graph_extractor.cpp
@@ -5,9 +5,8 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-#include <unordered_map>
 #include "graph_extractor.h"
-
+#include "definitions.h"
 
 graph_extractor::graph_extractor() {
 
@@ -134,7 +133,7 @@ void graph_extractor::extract_two_blocks_connected(graph_access & G,
                                                    graph_access & pair,
                                                    std::vector<NodeID> & mapping) {
         //// build reverse mapping
-        std::unordered_map<NodeID,NodeID> reverse_mapping;
+        extlib::unordered_map<NodeID,NodeID> reverse_mapping;
         NodeID nodes = 0;
         EdgeID edges = 0; // upper bound for number of edges
 

--- a/lib/tools/quality_metrics.cpp
+++ b/lib/tools/quality_metrics.cpp
@@ -6,13 +6,12 @@
  *****************************************************************************/
 
 #include <algorithm>
+#include <numeric>
 #include <cmath>
 
 #include "quality_metrics.h"
 #include "data_structure/union_find.h"
-
-#include <unordered_map>
-#include <numeric>
+#include "definitions.h"
 
 quality_metrics::quality_metrics() {
 }
@@ -94,7 +93,7 @@ EdgeWeight quality_metrics::edge_cut_connected(graph_access & G, int * partition
                 } endfor
         } endfor
 
-        std::unordered_map<NodeID, NodeID> size_right;
+        extlib::unordered_map<NodeID, NodeID> size_right;
         forall_nodes(G, node) {
                 size_right[uf.Find(node)] = 1;
         } endfor

--- a/parallel/modified_kahip/lib/data_structure/priority_queues/bucket_pq.h
+++ b/parallel/modified_kahip/lib/data_structure/priority_queues/bucket_pq.h
@@ -9,9 +9,9 @@
 #define BUCKET_PQ_EM8YJPA9
 
 #include <limits>
-#include <unordered_map>
 
 #include "priority_queue_interface.h"
+#include "definitions.h"
 
 class bucket_pq : public priority_queue_interface {
         public:
@@ -40,7 +40,7 @@ class bucket_pq : public priority_queue_interface {
                 EdgeWeight m_gain_span;
                 unsigned   m_max_idx; //points to the non-empty bucket with the largest gain
                 
-                std::unordered_map<NodeID, std::pair<Count, Gain> > m_queue_index;
+                extlib::unordered_map<NodeID, std::pair<Count, Gain> > m_queue_index;
                 std::vector< std::vector<NodeID> >             m_buckets;
 };
 

--- a/parallel/modified_kahip/lib/data_structure/priority_queues/maxNodeHeap.h
+++ b/parallel/modified_kahip/lib/data_structure/priority_queues/maxNodeHeap.h
@@ -10,10 +10,10 @@
 
 #include <limits>
 #include <vector>
-#include <unordered_map>
 #include <execinfo.h>
 
 #include "data_structure/priority_queues/priority_queue_interface.h"
+#include "definitions.h"
              
 typedef int Key;
 
@@ -85,7 +85,7 @@ class maxNodeHeap : public priority_queue_interface {
 
         private:
                 std::vector< PQElement >               m_elements;      // elements that contain the data
-                std::unordered_map<NodeID, int>   m_element_index; // stores index of the node in the m_elements array
+                extlib::unordered_map<NodeID, int>   m_element_index; // stores index of the node in the m_elements array
                 std::vector< std::pair<Key, int> >     m_heap;          // key and index in elements (pointer)
 
                 void siftUp( int pos );

--- a/parallel/modified_kahip/lib/definitions.h
+++ b/parallel/modified_kahip/lib/definitions.h
@@ -15,6 +15,8 @@
 #include "limits.h"
 #include "macros_assertions.h"
 #include "stdio.h"
+#include "robin_map.h"
+#include "robin_set.h"
 
 // allows us to disable most of the output during partitioning
 #ifdef KAFFPAOUTPUT
@@ -38,6 +40,19 @@ typedef EdgeWeight 	Gain;
 typedef int 		Color;
 typedef unsigned int 	Count;
 typedef std::vector<NodeID> boundary_starting_nodes;
+
+namespace extlib {
+
+template <typename Key, typename T>
+using unordered_map = tsl::robin_map<Key, T>;
+
+template <class Key, class T, class Hash, class KeyEqual>
+using unordered_map_with_custom_hash_and_comparator = tsl::robin_map<Key, T, Hash, KeyEqual>;
+
+template <typename Key>
+using unordered_set = tsl::robin_set<Key>;
+
+}
 
 const EdgeID UNDEFINED_EDGE            = std::numeric_limits<EdgeID>::max();
 const NodeID NOTMAPPED                 = std::numeric_limits<EdgeID>::max();

--- a/parallel/modified_kahip/lib/parallel_mh/galinier_combine/gal_combine.cpp
+++ b/parallel/modified_kahip/lib/parallel_mh/galinier_combine/gal_combine.cpp
@@ -17,6 +17,7 @@
 #include "uncoarsening/refinement/mixed_refinement.h"
 #include "uncoarsening/refinement/refinement.h"
 #include "uncoarsening/refinement/tabu_search/tabu_search.h"
+#include "definitions.h"
 
 gal_combine::gal_combine() {
                 
@@ -33,7 +34,7 @@ gal_combine::~gal_combine() {
 // apply our refinements and tabu search
 void gal_combine::perform_gal_combine( PartitionConfig & config, graph_access & G) {
         //first greedily compute a matching of the partitions
-        std::vector< std::unordered_map<PartitionID, unsigned> > counters(config.k);
+        std::vector< extlib::unordered_map<PartitionID, unsigned> > counters(config.k);
         forall_nodes(G, node) {
                 //boundary_pair bp;
                 if(counters[G.getPartitionIndex(node)].find(G.getSecondPartitionIndex(node)) != counters[G.getPartitionIndex(node)].end()) {
@@ -56,7 +57,7 @@ void gal_combine::perform_gal_combine( PartitionConfig & config, graph_access & 
                 PartitionID best_unassigned = config.k;
                 NodeWeight  best_value      = 0;
 
-                for( std::unordered_map<PartitionID, unsigned>::iterator it = counters[cur_partition].begin(); 
+                for( auto it = counters[cur_partition].begin();
                      it != counters[cur_partition].end(); ++it) {
                         if( rhs_matched[it->first] == false && it->second > best_value ) {
                                 best_unassigned = it->first; 

--- a/parallel/modified_kahip/lib/partition/coarsening/clustering/size_constraint_label_propagation.cpp
+++ b/parallel/modified_kahip/lib/partition/coarsening/clustering/size_constraint_label_propagation.cpp
@@ -5,9 +5,6 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-
-#include <unordered_map>
-
 #include <sstream>
 #include "../edge_rating/edge_ratings.h"
 #include "../matching/gpa/gpa_matching.h"
@@ -20,6 +17,7 @@
 #include "io/graph_io.h"
 
 #include "size_constraint_label_propagation.h"
+#include "definitions.h"
 
 size_constraint_label_propagation::size_constraint_label_propagation() {
                 
@@ -66,8 +64,7 @@ void size_constraint_label_propagation::ensemble_two_clusterings( graph_access &
                                                                   std::vector< NodeID > & output,
                                                                   NodeID & no_of_coarse_vertices) {
 
-
-        hash_ensemble new_mapping; 
+        extlib::unordered_map_with_custom_hash_and_comparator<ensemble_pair, data_ensemble_pair, hash_ensemble_pair, compare_ensemble_pair> new_mapping;
         no_of_coarse_vertices = 0;
         for( NodeID node = 0; node < lhs.size(); node++) {
                 ensemble_pair cur_pair;
@@ -213,7 +210,7 @@ void size_constraint_label_propagation::remap_cluster_ids(const PartitionConfig 
                                                           NodeID & no_of_coarse_vertices, bool apply_to_graph) {
 
         PartitionID cur_no_clusters = 0;
-        std::unordered_map<PartitionID, PartitionID> remap;
+        extlib::unordered_map<PartitionID, PartitionID> remap;
         forall_nodes(G, node) {
                 PartitionID cur_cluster = cluster_id[node];
                 //check wether we already had that

--- a/parallel/modified_kahip/lib/partition/coarsening/clustering/size_constraint_label_propagation.h
+++ b/parallel/modified_kahip/lib/partition/coarsening/clustering/size_constraint_label_propagation.h
@@ -8,7 +8,6 @@
 #ifndef SIZE_CONSTRAINT_LABEL_PROPAGATION_7SVLBKKT
 #define SIZE_CONSTRAINT_LABEL_PROPAGATION_7SVLBKKT
 
-#include <unordered_map>
 #include "../matching/matching.h"
 
 struct ensemble_pair {
@@ -18,31 +17,22 @@ struct ensemble_pair {
 };
 
 struct compare_ensemble_pair {
-        bool operator()(const ensemble_pair pair_a, const ensemble_pair pair_b) const {
-                bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
-                return eq;
+        bool operator()(const ensemble_pair& pair_a, const ensemble_pair& pair_b) const {
+                return pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs;
         }
 };
 
-struct hash_ensemble_pair{
-       size_t operator()(const ensemble_pair pair) const {
+struct hash_ensemble_pair {
+       size_t operator()(const ensemble_pair& pair) const {
                 return pair.lhs*pair.n + pair.rhs;
        }
 };
 
 struct data_ensemble_pair {
         NodeID mapping;
-
-        data_ensemble_pair() {
-                mapping = 0;
+        data_ensemble_pair() : mapping(0) {
         }
 };
-
-typedef std::unordered_map<const ensemble_pair, 
-                                data_ensemble_pair, 
-                                hash_ensemble_pair, 
-                                compare_ensemble_pair> hash_ensemble;
-
 
 class size_constraint_label_propagation : public matching {
         public:

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph.h
@@ -9,7 +9,6 @@
 #define AUGMENTED_QUOTIENT_GRAPH_E5ZEJUBV
 
 #include <algorithm>
-#include <unordered_map>
 #include <vector>
 
 #include "definitions.h"
@@ -53,7 +52,7 @@ struct block_pair_difference {
         }
 };
 
-typedef std::unordered_map<const boundary_pair, set_pairwise_local_searches, hash_boundary_pair_directed, compare_boundary_pair_directed> augmented_Qgraph_internal;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, set_pairwise_local_searches, hash_boundary_pair_directed, compare_boundary_pair_directed> augmented_Qgraph_internal;
 
 class augmented_Qgraph {
 public:

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
@@ -16,6 +16,7 @@
 #include "uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h"
 #include "uncoarsening/refinement/kway_graph_refinement/kway_stop_rule.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h"
+#include "definitions.h"
 
 augmented_Qgraph_fabric::augmented_Qgraph_fabric() {
 }
@@ -183,7 +184,7 @@ bool augmented_Qgraph_fabric::build_augmented_quotient_graph( PartitionConfig & 
                         } // else
 
                         start_block = cur_block;
-                        std::unordered_map< PartitionID, bool > allready_performed_local_search;
+                        extlib::unordered_map< PartitionID, bool > allready_performed_local_search;
 
                         while( boundary.getBlockWeight( cur_block ) <= config.upper_bound_partition ) {
                                 boundary_pair bp;

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/cycle_definitions.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/cycle_improvements/cycle_definitions.h
@@ -8,8 +8,7 @@
 #ifndef CYCLE_DEFINITIONS_4GQMW8PZ
 #define CYCLE_DEFINITIONS_4GQMW8PZ
 
-#include <unordered_map>
-
+#include "definitions.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h"
 
 struct undo_struct {
@@ -21,13 +20,13 @@ struct data_qgraph_edge {
         NodeID to_move;
         Gain gain;
 
-        data_qgraph_edge() {
-                to_move = std::numeric_limits<PartitionID>::max();
-                gain    = std::numeric_limits<PartitionID>::min();
+        data_qgraph_edge()
+        : to_move(std::numeric_limits<PartitionID>::max())
+        , gain(std::numeric_limits<PartitionID>::min())
+        {
         }
 };
 
-typedef std::unordered_map<const boundary_pair, data_qgraph_edge, hash_boundary_pair_directed, compare_boundary_pair_directed> edge_movements;
-
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, data_qgraph_edge, hash_boundary_pair_directed, compare_boundary_pair_directed> edge_movements;
 
 #endif /* end of include guard: DEFINITIONS_4GQMW8PZ */

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.cpp
@@ -6,13 +6,13 @@
  *****************************************************************************/
 
 #include <algorithm>
-#include <unordered_map>
 
 #include "kway_graph_refinement.h"
 #include "kway_graph_refinement_core.h"
 #include "kway_stop_rule.h"
 #include "quality_metrics.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 kway_graph_refinement::kway_graph_refinement() {
 }
@@ -63,7 +63,7 @@ void kway_graph_refinement::setup_start_nodes(PartitionConfig & config, graph_ac
         QuotientGraphEdges quotient_graph_edges;
         boundary.getQuotientGraphEdges(quotient_graph_edges);
 
-        std::unordered_map<NodeID, bool> allready_contained;
+        extlib::unordered_map<NodeID, bool> allready_contained;
 
         for( unsigned i = 0; i < quotient_graph_edges.size(); i++) {
                 boundary_pair & ret_value = quotient_graph_edges[i];

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
@@ -13,6 +13,7 @@
 #include "kway_stop_rule.h"
 #include "quality_metrics.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 kway_graph_refinement_core::kway_graph_refinement_core() {
 }
@@ -26,7 +27,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round(PartitionCon
                                                                     boundary_starting_nodes & start_nodes, 
                                                                     int step_limit, 
                                                                     vertex_moved_hashtable & moved_idx) {
-        std::unordered_map<PartitionID, PartitionID> touched_blocks;
+        extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
         return single_kway_refinement_round_internal(config, G, boundary, start_nodes, 
                                                      step_limit, moved_idx, false, touched_blocks);
 }
@@ -37,7 +38,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round(PartitionCon
                                                                     boundary_starting_nodes & start_nodes, 
                                                                     int step_limit, 
                                                                     vertex_moved_hashtable & moved_idx,
-                                                                    std::unordered_map<PartitionID, PartitionID> & touched_blocks) {
+                                                                    extlib::unordered_map<PartitionID, PartitionID> & touched_blocks) {
 
         return single_kway_refinement_round_internal(config, G, boundary, start_nodes, 
                                                      step_limit, moved_idx, true, touched_blocks);
@@ -51,7 +52,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round_internal(Par
                                                                     int step_limit,
                                                                     vertex_moved_hashtable & moved_idx,
                                                                     bool compute_touched_partitions,
-                                                                    std::unordered_map<PartitionID, PartitionID> &  touched_blocks) {
+                                                                    extlib::unordered_map<PartitionID, PartitionID> &  touched_blocks) {
 
         commons = kway_graph_refinement_commons::getInstance(config);
         refinement_pq* queue = NULL;

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.h
@@ -8,7 +8,7 @@
 #ifndef KWAY_GRAPH_REFINEMENT_CORE_PVGY97EW
 #define KWAY_GRAPH_REFINEMENT_CORE_PVGY97EW
 
-#include <unordered_map>
+
 #include <vector>
 
 #include "data_structure/priority_queues/priority_queue_interface.h"
@@ -17,6 +17,7 @@
 #include "tools/random_functions.h"
 #include "uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h"
 #include "uncoarsening/refinement/refinement.h"
+#include "definitions.h"
 
 class kway_graph_refinement_core  {
         public:
@@ -36,7 +37,7 @@ class kway_graph_refinement_core  {
                                                         boundary_starting_nodes & start_nodes, 
                                                         int step_limit, 
                                                         vertex_moved_hashtable & moved_idx,
-                                                        std::unordered_map<PartitionID, PartitionID> & touched_blocks); 
+                                                        extlib::unordered_map<PartitionID, PartitionID> & touched_blocks);
 
 
          private:
@@ -47,7 +48,7 @@ class kway_graph_refinement_core  {
                                                                 int step_limit,
                                                                 vertex_moved_hashtable & moved_idx,
                                                                 bool compute_touched_partitions,
-                                                                std::unordered_map<PartitionID, PartitionID> &  touched_blocks); 
+                                                                extlib::unordered_map<PartitionID, PartitionID> &  touched_blocks);
 
 
                 void init_queue_with_boundary(const PartitionConfig & config, 

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.cpp
@@ -6,7 +6,6 @@
  *****************************************************************************/
 
 #include <algorithm>
-#include <unordered_map>
 
 #include "kway_graph_refinement_core.h"
 #include "kway_stop_rule.h"
@@ -48,7 +47,7 @@ int multitry_kway_fm::perform_refinement(PartitionConfig & config, graph_access 
                         todolist.push_back(start_nodes[i]);
                 }
 
-                std::unordered_map<PartitionID, PartitionID> touched_blocks;
+                extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
                 EdgeWeight improvement = start_more_locallized_search(config, G,  boundary, 
                                                                       init_neighbors, false, touched_blocks, 
                                                                       todolist);
@@ -70,7 +69,7 @@ int multitry_kway_fm::perform_refinement_around_parts(PartitionConfig & config, 
                                                       complete_boundary & boundary, bool init_neighbors, 
                                                       unsigned alpha, 
                                                       PartitionID & lhs, PartitionID & rhs, 
-                                                      std::unordered_map<PartitionID, PartitionID> & touched_blocks) {
+                                                      extlib::unordered_map<PartitionID, PartitionID> & touched_blocks) {
         commons = kway_graph_refinement_commons::getInstance(config);
 
         unsigned tmp_alpha                = config.kway_adaptive_limits_alpha;
@@ -108,7 +107,7 @@ int multitry_kway_fm::perform_refinement_around_parts(PartitionConfig & config, 
 int multitry_kway_fm::start_more_locallized_search(PartitionConfig & config, graph_access & G, 
                                                    complete_boundary & boundary, bool init_neighbors, 
                                                    bool compute_touched_blocks, 
-                                                   std::unordered_map<PartitionID, PartitionID> & touched_blocks, 
+                                                   extlib::unordered_map<PartitionID, PartitionID> & touched_blocks,
                                                    std::vector<NodeID> & todolist) {
 
         random_functions::permutate_vector_good(todolist, false);

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.h
@@ -27,7 +27,7 @@ class multitry_kway_fm {
                                                     complete_boundary & boundary, bool init_neighbors, 
                                                     unsigned alpha, 
                                                     PartitionID & lhs, PartitionID & rhs,
-                                                    std::unordered_map<PartitionID, PartitionID> & touched_blocks);
+                                                    extlib::unordered_map<PartitionID, PartitionID> & touched_blocks);
 
 
         private:
@@ -35,7 +35,7 @@ class multitry_kway_fm {
                                                  complete_boundary & boundary, 
                                                  bool init_neighbors, 
                                                  bool compute_touched_blocks, 
-                                                 std::unordered_map<PartitionID, PartitionID> & touched_blocks, 
+                                                 extlib::unordered_map<PartitionID, PartitionID> & touched_blocks,
                                                  std::vector<NodeID> & todolist);
 
                 kway_graph_refinement_commons* commons;

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/vertex_moved_hashtable.h
@@ -8,14 +8,12 @@
 #ifndef VMOVEDHT_4563r97820954
 #define VMOVEDHT_4563r97820954
 
-#include <unordered_map>
-
 #include "definitions.h"
 #include "limits.h"
 
 struct compare_nodes {
-        bool operator()(const NodeID lhs, const NodeID rhs) const {
-                return (lhs == rhs);
+        bool operator()(const NodeID& lhs, const NodeID& rhs) const {
+                return lhs == rhs;
         }
 };
 
@@ -25,8 +23,8 @@ const NodeID MOVED = 0;
 
 struct moved_index {
        NodeID index;
-       moved_index() {
-                index = NOT_MOVED;
+       moved_index()
+       : index(NOT_MOVED) {
        }
 };
 
@@ -36,6 +34,6 @@ struct hash_nodes {
        }
 };
 
-typedef std::unordered_map<const NodeID, moved_index, hash_nodes, compare_nodes> vertex_moved_hashtable;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<NodeID, moved_index, hash_nodes, compare_nodes> vertex_moved_hashtable;
 
 #endif

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/boundary_lookup.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/boundary_lookup.h
@@ -8,8 +8,6 @@
 #ifndef BOUNDARY_LOOKUP_2JMSKBSI
 #define BOUNDARY_LOOKUP_2JMSKBSI
 
-#include <unordered_map>
-
 #include "definitions.h"
 #include "limits.h"
 #include "partial_boundary.h"
@@ -20,19 +18,16 @@ struct boundary_pair {
         PartitionID rhs;
 };
 
-
 struct compare_boundary_pair {
-        bool operator()(const boundary_pair pair_a, const boundary_pair pair_b) const {
-                bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
-                     eq = eq || (pair_a.lhs == pair_b.rhs && pair_a.rhs == pair_b.lhs); 
-                return eq;
+        bool operator()(const boundary_pair& pair_a, const boundary_pair& pair_b) const {
+                const bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
+                return eq || (pair_a.lhs == pair_b.rhs && pair_a.rhs == pair_b.lhs);
         }
 };
 
 struct compare_boundary_pair_directed {
-        bool operator()(const boundary_pair pair_a, const boundary_pair pair_b) const {
-                bool eq = (pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs);
-                return eq;
+        bool operator()(const boundary_pair& pair_a, const boundary_pair& pair_b) const {
+                return pair_a.lhs == pair_b.lhs && pair_a.rhs == pair_b.rhs;
         }
 };
 
@@ -45,22 +40,23 @@ struct data_boundary_pair {
 
         bool initialized;
 
-        data_boundary_pair() {
-                edge_cut = 0;
-                lhs = std::numeric_limits<PartitionID>::max();
-                rhs = std::numeric_limits<PartitionID>::max();
-                initialized = false;
+        data_boundary_pair()
+        : lhs(std::numeric_limits<PartitionID>::max())
+        , rhs(std::numeric_limits<PartitionID>::max())
+        , edge_cut(0)
+        , initialized(false)
+        {
         }
 };
 
 struct hash_boundary_pair_directed{
-       size_t operator()(const boundary_pair pair) const {
+       size_t operator()(const boundary_pair& pair) const {
                 return pair.lhs*pair.k + pair.rhs;
        }
 };
 
 struct hash_boundary_pair{
-       size_t operator()(const boundary_pair pair) const {
+       size_t operator()(const boundary_pair& pair) const {
                 if(pair.lhs < pair.rhs) 
                         return pair.lhs*pair.k + pair.rhs;
                 else 
@@ -68,7 +64,7 @@ struct hash_boundary_pair{
        }
 };
 
-typedef std::unordered_map<const boundary_pair, data_boundary_pair, hash_boundary_pair, compare_boundary_pair> block_pairs;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<boundary_pair, data_boundary_pair, hash_boundary_pair, compare_boundary_pair> block_pairs;
 
 
 

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/complete_boundary.h
@@ -9,13 +9,13 @@
 #define COMPLETE_BOUNDARY_URZZFDEI
 
 #include <execinfo.h>
-#include <unordered_map>
 #include <utility>
 
 #include "boundary_lookup.h"
 #include "data_structure/graph_access.h"
 #include "partial_boundary.h"
 #include "partition_config.h"
+#include "definitions.h"
 
 struct block_informations {
         NodeWeight block_weight;
@@ -134,12 +134,11 @@ inline void complete_boundary::build() {
                 } endfor
         } endfor
 
-        block_pairs::iterator iter; 
-        for(iter = m_pairs.begin(); iter != m_pairs.end(); iter++ ) { 
-                data_boundary_pair& value = iter->second;
-                value.edge_cut /= 2;
+        for (auto it = m_pairs.begin(); it != m_pairs.end(); ++it)
+        {
+            auto& tmp = it.value();
+            tmp.edge_cut /= 2;
         }
-
 }
 
 inline void complete_boundary::build_from_coarser(complete_boundary * coarser_boundary, 
@@ -205,10 +204,10 @@ inline void complete_boundary::build_from_coarser(complete_boundary * coarser_bo
                 setBlockWeight(p, coarser_boundary->getBlockWeight(p));
         }
 
-        block_pairs::iterator iter; 
-        for(iter = m_pairs.begin(); iter != m_pairs.end(); iter++ ) { 
-                data_boundary_pair& value = iter->second;
-                value.edge_cut /= 2;
+        for (auto it = m_pairs.begin(); it != m_pairs.end(); ++it)
+        {
+            auto& tmp = it.value();
+            tmp.edge_cut /= 2;
         }
 }
 
@@ -431,13 +430,13 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
         std::vector<PartitionID> rhs_neighbors;
         getNeighbors(rhs, rhs_neighbors);
 
-        std::unordered_map<NodeID, bool> allready_contained;
+        extlib::unordered_map<NodeID, bool> allready_contained;
         for( unsigned i = 0; i < lhs_neighbors.size(); i++) {
                 PartitionID neighbor = lhs_neighbors[i];
                 PartialBoundary & partial_boundary_lhs = getDirectedBoundary(lhs, lhs, neighbor);
                 forall_boundary_nodes(partial_boundary_lhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), lhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -446,7 +445,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_neighbor = getDirectedBoundary(neighbor, lhs, neighbor);
                 forall_boundary_nodes(partial_boundary_neighbor, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), neighbor);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -458,7 +457,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_rhs = getDirectedBoundary(rhs, rhs, neighbor);
                 forall_boundary_nodes(partial_boundary_rhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), rhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -467,7 +466,7 @@ void complete_boundary::setup_start_nodes_around_blocks(graph_access & G,
                 PartialBoundary & partial_boundary_neighbor = getDirectedBoundary(neighbor, rhs, neighbor);
                 forall_boundary_nodes(partial_boundary_neighbor, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), neighbor);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -480,7 +479,7 @@ void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_startin
         QuotientGraphEdges quotient_graph_edges;
         getQuotientGraphEdges(quotient_graph_edges);
 
-        std::unordered_map<NodeID, bool> allready_contained;
+        extlib::unordered_map<NodeID, bool> allready_contained;
         
         for( unsigned i = 0; i < quotient_graph_edges.size(); i++) {
                 boundary_pair & ret_value = quotient_graph_edges[i];
@@ -490,7 +489,7 @@ void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_startin
                 PartialBoundary & partial_boundary_lhs = getDirectedBoundary(lhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_lhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), lhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end() ) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }
@@ -499,7 +498,7 @@ void complete_boundary::setup_start_nodes_all(graph_access & G, boundary_startin
                 PartialBoundary & partial_boundary_rhs = getDirectedBoundary(rhs, lhs, rhs);
                 forall_boundary_nodes(partial_boundary_rhs, cur_bnd_node) {
                         ASSERT_EQ(G.getPartitionIndex(cur_bnd_node), rhs);
-                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) { 
+                        if(allready_contained.find(cur_bnd_node) == allready_contained.end()) {
                                 start_nodes.push_back(cur_bnd_node);
                                 allready_contained[cur_bnd_node] = true;
                         }

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/edge_cut_flow_solver.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/flow_solving_kernel/edge_cut_flow_solver.cpp
@@ -11,12 +11,11 @@
 #include <map>
 #include <math.h>
 #include <sstream>
-#include <unordered_map>
 
 #include "edge_cut_flow_solver.h"
 #include "flow_macros.h"
 #include "most_balanced_minimum_cuts/most_balanced_minimum_cuts.h"
-
+#include "definitions.h"
 
 edge_cut_flow_solver::edge_cut_flow_solver() {
 }
@@ -84,7 +83,7 @@ EdgeWeight edge_cut_flow_solver::convert_ds( const PartitionConfig & config,
         //building up the graph as in parse.h of hi_pr code
         NodeID idx = 0;
         new_to_old_ids.resize(lhs_boundary_stripe.size() + rhs_boundary_stripe.size());
-        std::unordered_map<NodeID, NodeID> old_to_new;
+        extlib::unordered_map<NodeID, NodeID> old_to_new;
         for( unsigned i = 0; i < lhs_boundary_stripe.size(); i++) {
                 G.setPartitionIndex(lhs_boundary_stripe[i], BOUNDARY_STRIPE_NODE);
                 new_to_old_ids[idx]                = lhs_boundary_stripe[i];

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/most_balanced_minimum_cuts/most_balanced_minimum_cuts.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/flow_refinement/most_balanced_minimum_cuts/most_balanced_minimum_cuts.cpp
@@ -5,11 +5,10 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-#include <unordered_map>
-
 #include "algorithms/strongly_connected_components.h"
 #include "algorithms/topological_sort.h"
 #include "most_balanced_minimum_cuts.h"
+#include "definitions.h"
 
 most_balanced_minimum_cuts::most_balanced_minimum_cuts() {
 
@@ -156,7 +155,7 @@ void most_balanced_minimum_cuts::build_internal_scc_graph( graph_access & residu
         scc_graph.start_construction(comp_count, edge_count);
         for( unsigned i = 0; i < (unsigned) comp_count; i++) {
                 NodeID node = scc_graph.new_node();
-                std::unordered_map<NodeID, bool> allready_contained;
+                extlib::unordered_map<NodeID, bool> allready_contained;
                 for(unsigned j = 0; j < edges[i].size(); j++) {
                         if(allready_contained.find(edges[i][j]) == allready_contained.end()) {
                                 scc_graph.new_edge(node, edges[i][j]);

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/partial_boundary.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/partial_boundary.h
@@ -8,23 +8,20 @@
 #ifndef PARTIAL_BOUNDARY_963CRO9F_
 #define PARTIAL_BOUNDARY_963CRO9F_
 
-#include <unordered_map>
 #include "definitions.h"
 
 struct compare_nodes_contains {
-        bool operator()(const NodeID lhs, const NodeID rhs) const {
-                return (lhs == rhs);
+        bool operator()(const NodeID& lhs, const NodeID& rhs) const {
+                return lhs == rhs;
         }
 };
 
-
 struct is_boundary {
-       bool contains;
-       is_boundary() {
-                contains = false;
-       }
+        bool contains;
+        is_boundary()
+        : contains(false) {
+        }
 };
-
 
 struct hash_boundary_nodes {
        size_t operator()(const NodeID idx) const {
@@ -32,7 +29,7 @@ struct hash_boundary_nodes {
        }
 };
 
-typedef std::unordered_map<const NodeID, is_boundary, hash_boundary_nodes, compare_nodes_contains> is_boundary_node_hashtable;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<NodeID, is_boundary, hash_boundary_nodes, compare_nodes_contains> is_boundary_node_hashtable;
 
 class PartialBoundary {
         public:

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_refinement.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_refinement.cpp
@@ -5,8 +5,6 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-#include <unordered_map>
-
 #include "2way_fm_refinement/two_way_fm.h"
 #include "complete_boundary.h"
 #include "flow_refinement/two_way_flow_refinement.h"
@@ -16,6 +14,7 @@
 #include "quotient_graph_scheduling/simple_quotient_graph_scheduler.h"
 #include "uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement.h"
 #include "uncoarsening/refinement/kway_graph_refinement/multitry_kway_fm.h"
+#include "definitions.h"
 
 quotient_graph_refinement::quotient_graph_refinement() {
 
@@ -107,7 +106,7 @@ EdgeWeight quotient_graph_refinement::perform_refinement(PartitionConfig & confi
                 EdgeWeight multitry_improvement = 0;
                 if(config.refinement_scheduling_algorithm == REFINEMENT_SCHEDULING_ACTIVE_BLOCKS_REF_KWAY ) {
                         multitry_kway_fm kway_ref;
-                        std::unordered_map<PartitionID, PartitionID> touched_blocks;
+                        extlib::unordered_map<PartitionID, PartitionID> touched_blocks;
 
                         multitry_improvement = kway_ref.perform_refinement_around_parts(cfg, G, 
                                                                                 boundary, true, 

--- a/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/active_block_quotient_graph_scheduler.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/active_block_quotient_graph_scheduler.h
@@ -8,11 +8,10 @@
 #ifndef ACTIVE_BLOCK_QUOTIENT_GRAPH_SCHEDULER_2QATIGSY
 #define ACTIVE_BLOCK_QUOTIENT_GRAPH_SCHEDULER_2QATIGSY
 
-#include <unordered_map>
-
 #include "partition_config.h"
 #include "quotient_graph_scheduling.h"
 #include "random_functions.h"
+#include "definitions.h"
 
 class active_block_quotient_graph_scheduler : public quotient_graph_scheduling {
         public:
@@ -27,7 +26,7 @@ class active_block_quotient_graph_scheduler : public quotient_graph_scheduling {
                 virtual void pushStatistics(qgraph_edge_statistics & statistic);
                 virtual void init();
 
-                void activate_blocks(std::unordered_map<PartitionID, PartitionID> & blocks);
+                void activate_blocks(extlib::unordered_map<PartitionID, PartitionID> & blocks);
 
         private: 
                 QuotientGraphEdges & m_quotient_graph_edges;
@@ -81,9 +80,8 @@ inline void active_block_quotient_graph_scheduler::pushStatistics(qgraph_edge_st
         }
 }
 
-inline void active_block_quotient_graph_scheduler::activate_blocks(std::unordered_map<PartitionID, PartitionID> & blocks) {
-        std::unordered_map<PartitionID, PartitionID>::iterator it;
-        for(it = blocks.begin(); it != blocks.end(); ++it) {
+inline void active_block_quotient_graph_scheduler::activate_blocks(extlib::unordered_map<PartitionID, PartitionID> & blocks) {
+        for(auto it = blocks.begin(); it != blocks.end(); ++it) {
              m_is_block_active[it->first] = true;
         }
 }

--- a/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_algorithm.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_algorithm.cpp
@@ -11,6 +11,7 @@
 #include "uncoarsening/refinement/quotient_graph_refinement/quotient_graph_scheduling/simple_quotient_graph_scheduler.h"
 #include "vertex_separator_algorithm.h"
 #include "vertex_separator_flow_solver.h"
+#include "definitions.h"
 
 vertex_separator_algorithm::vertex_separator_algorithm() {
 
@@ -33,7 +34,7 @@ void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig 
 
         quotient_graph_scheduling* scheduler = new simple_quotient_graph_scheduler(cfg, qgraph_edges,qgraph_edges.size()); 
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> already_separator;
         do {
                 boundary_pair & bp = scheduler->getNext();
                 PartitionID lhs = bp.lhs;
@@ -46,13 +47,13 @@ void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig 
                 PartialBoundary & rhs_b = boundary.getDirectedBoundary(rhs, lhs, rhs);
 
                 forall_boundary_nodes(lhs_b, cur_bnd_node) {
-                        if(allready_separator.find(cur_bnd_node) == allready_separator.end()) {
+                        if(already_separator.find(cur_bnd_node) == already_separator.end()) {
                                 start_nodes_lhs.push_back(cur_bnd_node);
                         }
                 } endfor
 
                 forall_boundary_nodes(rhs_b, cur_bnd_node) {
-                        if(allready_separator.find(cur_bnd_node) == allready_separator.end()) {
+                        if(already_separator.find(cur_bnd_node) == already_separator.end()) {
                                 start_nodes_rhs.push_back(cur_bnd_node);
                         }
                 } endfor
@@ -61,18 +62,17 @@ void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig 
                 std::vector<NodeID> separator;
                 vsfs.find_separator(config, G, lhs, rhs, start_nodes_lhs, start_nodes_rhs, separator);
                 for( unsigned i = 0; i < separator.size(); i++) {
-                        allready_separator[separator[i]] = true;
+                        already_separator[separator[i]] = true;
                 }
                 //*************************** end **************************************** 
         } while(!scheduler->hasFinished());
 
 
         // now print the computed vertex separator to disk
-        std::unordered_map<NodeID, bool>::iterator it;
-        for( it = allready_separator.begin(); it != allready_separator.end(); ++it) {
+        for(auto it = already_separator.begin(); it != already_separator.end(); ++it) {
                 overall_separator.push_back(it->first);
         }
-        is_vertex_separator(G, allready_separator);         
+        is_vertex_separator(G, already_separator);
 }
 
 void vertex_separator_algorithm::compute_vertex_separator(const PartitionConfig & config, 
@@ -101,7 +101,7 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
 
         quotient_graph_scheduling* scheduler = new simple_quotient_graph_scheduler(cfg, qgraph_edges,qgraph_edges.size()); 
 
-        std::unordered_map<NodeID, bool> allready_separator;
+        extlib::unordered_map<NodeID, bool> already_separator;
         do {
                 boundary_pair & bp = scheduler->getNext();
                 PartitionID lhs = bp.lhs;
@@ -115,16 +115,16 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
 
                 if(lhs_b.size() < rhs_b.size()) {
                         forall_boundary_nodes(lhs_b, cur_bnd_node) {
-                                if(allready_separator.find(cur_bnd_node) == allready_separator.end()) {
+                                if(already_separator.find(cur_bnd_node) == already_separator.end()) {
                                         //overall_separator.push_back(cur_bnd_node);
-                                        allready_separator[cur_bnd_node] = true;
+                                        already_separator[cur_bnd_node] = true;
                                 }
                         } endfor
                 } else {
                         forall_boundary_nodes(rhs_b, cur_bnd_node) {
-                                if(allready_separator.find(cur_bnd_node) == allready_separator.end()) {
+                                if(already_separator.find(cur_bnd_node) == already_separator.end()) {
                                         //overall_separator.push_back(cur_bnd_node);
-                                        allready_separator[cur_bnd_node] = true;
+                                        already_separator[cur_bnd_node] = true;
                                 }
                         } endfor
                 }
@@ -134,14 +134,13 @@ void vertex_separator_algorithm::compute_vertex_separator_simple(const Partition
 
 
         // now print the computed vertex separator to disk
-        std::unordered_map<NodeID, bool>::iterator it;
-        for( it = allready_separator.begin(); it != allready_separator.end(); ++it) {
+        for(auto it = already_separator.begin(); it != already_separator.end(); ++it) {
                 overall_separator.push_back(it->first);
         }
-        is_vertex_separator(G, allready_separator);         
+        is_vertex_separator(G, already_separator);
 }
 
-bool vertex_separator_algorithm::is_vertex_separator(graph_access & G, std::unordered_map<NodeID, bool> & separator) {
+bool vertex_separator_algorithm::is_vertex_separator(graph_access & G, extlib::unordered_map<NodeID, bool> & separator) {
          forall_nodes(G, node) {
                 forall_out_edges(G, e, node) {
                         NodeID target = G.getEdgeTarget(e);

--- a/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_algorithm.h
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_algorithm.h
@@ -34,7 +34,7 @@ class vertex_separator_algorithm {
                                               complete_boundary & boundary);
 
                 //ASSERTIONS
-                bool is_vertex_separator(graph_access & G, std::unordered_map<NodeID, bool> & separator);
+                bool is_vertex_separator(graph_access& G, tsl::robin_map< NodeID, bool >& separator);
 
 };
 

--- a/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_flow_solver.cpp
+++ b/parallel/modified_kahip/lib/partition/uncoarsening/separator/vertex_separator_flow_solver.cpp
@@ -8,10 +8,10 @@
 #include <algorithm>
 #include <map>
 #include <math.h>
-#include <unordered_map>
 
 #include "vertex_separator_flow_solver.h"
 #include "flow_solving_kernel/flow_macros.h"
+#include "definitions.h"
 
 vertex_separator_flow_solver::vertex_separator_flow_solver() {
 
@@ -140,7 +140,7 @@ bool vertex_separator_flow_solver::construct_flow_pb( const PartitionConfig & co
         //build mappings from old to new node ids and reverse
         NodeID idx = 0;
         new_to_old_ids.resize(lhs_nodes.size() + rhs_nodes.size());
-        std::unordered_map<NodeID, NodeID> old_to_new;
+        extlib::unordered_map<NodeID, NodeID> old_to_new;
         for( unsigned i = 0; i < lhs_nodes.size(); i++) {
                 new_to_old_ids[idx] = lhs_nodes[i];
                 old_to_new[lhs_nodes[i]] = idx++ ;

--- a/parallel/modified_kahip/lib/partition/w_cycles/wcycle_partitioner.h
+++ b/parallel/modified_kahip/lib/partition/w_cycles/wcycle_partitioner.h
@@ -13,6 +13,7 @@
 #include "data_structure/graph_access.h"
 #include "partition_config.h"
 #include "uncoarsening/refinement/refinement.h"
+#include "definitions.h"
 
 class wcycle_partitioner {
         public:
@@ -30,7 +31,7 @@ class wcycle_partitioner {
                 unsigned   m_deepest_level;
                 stop_rule* m_coarsening_stop_rule;
 
-                std::unordered_map<unsigned, bool> m_have_been_level_down;
+                extlib::unordered_map<unsigned, bool> m_have_been_level_down;
 };
 
 #endif /* end of include guard: WCYCLE_PARTITIONER_EPNDQMK */

--- a/parallel/modified_kahip/lib/tools/graph_extractor.cpp
+++ b/parallel/modified_kahip/lib/tools/graph_extractor.cpp
@@ -5,8 +5,8 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
-#include <unordered_map>
 #include "graph_extractor.h"
+#include "definitions.h"
 
 graph_extractor::graph_extractor() {
 
@@ -133,7 +133,7 @@ void graph_extractor::extract_two_blocks_connected(graph_access & G,
                                                    graph_access & pair,
                                                    std::vector<NodeID> & mapping) {
         //// build reverse mapping
-        std::unordered_map<NodeID,NodeID> reverse_mapping;
+        extlib::unordered_map<NodeID,NodeID> reverse_mapping;
         NodeID nodes = 0;
         EdgeID edges = 0; // upper bound for number of edges
 

--- a/parallel/modified_kahip/lib/tools/quality_metrics.cpp
+++ b/parallel/modified_kahip/lib/tools/quality_metrics.cpp
@@ -10,8 +10,7 @@
 
 #include "quality_metrics.h"
 #include "data_structure/union_find.h"
-
-#include <unordered_map>
+#include "definitions.h"
 
 quality_metrics::quality_metrics() {
 }
@@ -93,7 +92,7 @@ EdgeWeight quality_metrics::edge_cut_connected(graph_access & G, int * partition
                 } endfor
         } endfor
 
-        std::unordered_map<NodeID, NodeID> size_right;
+        extlib::unordered_map<NodeID, NodeID> size_right;
         forall_nodes(G, node) {
                 size_right[uf.Find(node)] = 1;
         } endfor

--- a/parallel/parallel_src/app/edge_list_to_metis_graph.cpp
+++ b/parallel/parallel_src/app/edge_list_to_metis_graph.cpp
@@ -17,6 +17,7 @@
 #include "data_structure/hashed_graph.h"
 #include "data_structure/parallel_graph_access.h"
 #include "io/parallel_graph_io.h"
+#include "definitions.h"
 
 using namespace std;
 
@@ -48,7 +49,7 @@ int main(int argn, char **argv)
         std::getline(in, line); // skip first line
         std::cout <<  line  << std::endl;
 
-        std::unordered_map< NodeID, std::unordered_map< NodeID, int> > source_targets;
+        extlib::unordered_map< NodeID, extlib::unordered_map< NodeID, int> > source_targets;
                         
         std::cout <<  "starting io"  << std::endl;
         EdgeID edge_counter = 0;
@@ -84,8 +85,7 @@ int main(int argn, char **argv)
         std::cout <<  "io done"  << std::endl;
 
         NodeID distinct_nodes = source_targets.size();
-        std::unordered_map< NodeID, NodeID > map_orignal_id_to_consequtive;
-        //std::unordered_map< NodeID, std::unordered_map< NodeID, bool > >::iterator it;
+        extlib::unordered_map< NodeID, NodeID > map_orignal_id_to_consequtive;
         NodeID counter = 0;
         for( auto it = source_targets.begin(); it != source_targets.end(); it++) {
                 if( map_orignal_id_to_consequtive.find(it->first) ==  map_orignal_id_to_consequtive.end()) {

--- a/parallel/parallel_src/app/friendster_list_to_metis_graph.cpp
+++ b/parallel/parallel_src/app/friendster_list_to_metis_graph.cpp
@@ -45,7 +45,7 @@ int main(int argn, char **argv)
 
         std::string line;
 
-        std::unordered_map< NodeID, std::unordered_map< NodeID, int> > source_targets;
+        extlib::unordered_map< NodeID, extlib::unordered_map< NodeID, int> > source_targets;
                         
         std::cout <<  "starting io"  << std::endl;
         EdgeID edge_counter = 0;
@@ -95,7 +95,7 @@ int main(int argn, char **argv)
         std::cout <<  "io done"  << std::endl;
 
         NodeID distinct_nodes = source_targets.size();
-        std::unordered_map< NodeID, NodeID > map_orignal_id_to_consequtive;
+        extlib::unordered_map< NodeID, NodeID > map_orignal_id_to_consequtive;
         NodeID counter = 0;
         for( auto it = source_targets.begin(); it != source_targets.end(); it++) {
                 if( map_orignal_id_to_consequtive.find(it->first) ==  map_orignal_id_to_consequtive.end()) {

--- a/parallel/parallel_src/lib/data_structure/balance_management.h
+++ b/parallel/parallel_src/lib/data_structure/balance_management.h
@@ -9,7 +9,6 @@
 #define BALANCE_MANAGEMENT_NJRUTX5K
 
 #include <vector>
-#include <unordered_map>
 #include "definitions.h"
 
 /* This class gives you the amount of weight that is currently in a block.

--- a/parallel/parallel_src/lib/data_structure/balance_management_coarsening.h
+++ b/parallel/parallel_src/lib/data_structure/balance_management_coarsening.h
@@ -8,6 +8,7 @@
 #ifndef BALANCE_MANAGEMENT_COARSENING_TS6EZN5A
 #define BALANCE_MANAGEMENT_COARSENING_TS6EZN5A
 
+#include "definitions.h"
 #include "balance_management.h"
 
 class parallel_graph_access;
@@ -25,7 +26,7 @@ public:
         virtual void update();
 
 private:
-        std::unordered_map< PartitionID, long > m_fuzzy_block_weights;
+        extlib::unordered_map< PartitionID, long > m_fuzzy_block_weights;
 };
 
 

--- a/parallel/parallel_src/lib/data_structure/hashed_graph.h
+++ b/parallel/parallel_src/lib/data_structure/hashed_graph.h
@@ -8,8 +8,6 @@
 #ifndef HASHED_GRAPH_DG1JG7O0
 #define HASHED_GRAPH_DG1JG7O0
 
-#include <unordered_map>
-
 #include "definitions.h"
 #include "limits.h"
 
@@ -19,25 +17,23 @@ struct hashed_edge {
         NodeID target;
 };
 
-
 struct compare_hashed_edge {
-        bool operator()(const hashed_edge e_1, const hashed_edge e_2) const {
-                bool eq = (e_1.source == e_2.source && e_1.target == e_2.target);
-                     eq = eq || (e_1.source == e_2.target && e_1.target == e_2.source); 
-                return eq;
+        bool operator()(const hashed_edge& e_1, const hashed_edge& e_2) const {
+                return (e_1.source == e_2.source && e_1.target == e_2.target) ||
+                       (e_1.source == e_2.target && e_1.target == e_2.source);
         }
 };
 
-struct data_hashed_edge{
+struct data_hashed_edge {
         NodeWeight weight;
 
-        data_hashed_edge() {
-                weight = 0;
+        data_hashed_edge()
+        : weight(0) {
         }
 };
 
 struct hash_hashed_edge {
-       ULONG operator()(const hashed_edge e) const {
+       ULONG operator()(const hashed_edge& e) const {
                 if(e.source < e.target) 
                         return e.source*e.k + e.target;
                 else 
@@ -45,7 +41,7 @@ struct hash_hashed_edge {
        }
 };
 
-typedef std::unordered_map<const hashed_edge, data_hashed_edge, hash_hashed_edge, compare_hashed_edge> hashed_graph;
+typedef extlib::unordered_map_with_custom_hash_and_comparator<hashed_edge, data_hashed_edge, hash_hashed_edge, compare_hashed_edge> hashed_graph;
 
 
 #endif /* end of include guard: HASHED_GRAPH_DG1JG7O0 */

--- a/parallel/parallel_src/lib/data_structure/parallel_graph_access.h
+++ b/parallel/parallel_src/lib/data_structure/parallel_graph_access.h
@@ -8,9 +8,7 @@
 #ifndef PARALLEL_GRAPH_ACCESS_X6O9MRS8
 #define PARALLEL_GRAPH_ACCESS_X6O9MRS8
 
-
 #include <mpi.h>
-#include <unordered_map>
 #include <iostream>
 #include <ostream>
 #include <fstream>
@@ -20,6 +18,7 @@
 #include "definitions.h"
 #include "partition_config.h"
 #include "tools/timer.h"
+#include "definitions.h"
 
 struct Node {
     EdgeID firstEdge;
@@ -523,7 +522,7 @@ private:
         std::vector<NodeID>                     m_range_array;
         std::vector<EdgeID>                     m_edge_range_array;
 
-        std::unordered_map<NodeID, NodeID> m_global_to_local_id;
+        extlib::unordered_map<NodeID, NodeID> m_global_to_local_id;
 
         NodeID m_ghost_adddata_array_offset; // node id of ghost node - offset to get the position in add data  
         NodeID m_divisor; // needed to compute the target id of a ghost node

--- a/parallel/parallel_src/lib/definitions.h
+++ b/parallel/parallel_src/lib/definitions.h
@@ -15,6 +15,8 @@
 #include "limits.h"
 #include "macros_assertions.h"
 #include "stdio.h"
+#include "robin_map.h"
+#include "robin_set.h"
 
 // allows us to disable most of the output during partitioning
 #ifndef NOOUTPUT 
@@ -38,6 +40,19 @@ typedef unsigned long long EdgeWeight;
 typedef int PEID; 
 
 const PEID ROOT = 0;
+
+namespace extlib {
+
+template <typename Key, typename T>
+using unordered_map = tsl::robin_map<Key, T>;
+
+template <class Key, class T, class Hash, class KeyEqual>
+using unordered_map_with_custom_hash_and_comparator = tsl::robin_map<Key, T, Hash, KeyEqual>;
+
+template <typename Key>
+using unordered_set = tsl::robin_set<Key>;
+
+}
 
 typedef enum {
         PERMUTATION_QUALITY_NONE, 

--- a/parallel/parallel_src/lib/distributed_partitioning/distributed_partitioner.cpp
+++ b/parallel/parallel_src/lib/distributed_partitioning/distributed_partitioner.cpp
@@ -155,7 +155,7 @@ void distributed_partitioner::vcycle( MPI_Comm communicator, PPartitionConfig & 
         config.upper_bound_cluster = config.upper_bound_partition/(1.0*config.cluster_coarsening_factor);
         G.init_balance_management( config );
 
-        //parallel_label_compress< std::unordered_map< NodeID, NodeWeight> > plc;
+        //parallel_label_compress< extlib::unordered_map< NodeID, NodeWeight> > plc;
         parallel_label_compress< linear_probing_hashmap  > plc;
         plc.perform_parallel_label_compression ( config, G, true);
 

--- a/parallel/parallel_src/lib/parallel_contraction_projection/parallel_block_down_propagation.cpp
+++ b/parallel/parallel_src/lib/parallel_contraction_projection/parallel_block_down_propagation.cpp
@@ -5,6 +5,7 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
+#include "definitions.h"
 #include "parallel_block_down_propagation.h"
 
 parallel_block_down_propagation::parallel_block_down_propagation() {
@@ -20,7 +21,7 @@ void parallel_block_down_propagation::propagate_block_down( MPI_Comm communicato
                                                             parallel_graph_access & Q) {
 
 
-        std::unordered_map< NodeID, NodeID > coarse_block_ids; 
+        extlib::unordered_map< NodeID, NodeID > coarse_block_ids;
 
         forall_local_nodes(G, node) {
                 NodeID cur_cnode = G.getCNode( node );

--- a/parallel/parallel_src/lib/parallel_contraction_projection/parallel_contraction.h
+++ b/parallel/parallel_src/lib/parallel_contraction_projection/parallel_contraction.h
@@ -8,6 +8,7 @@
 #ifndef PARALLEL_CONTRACTION_64O127GD
 #define PARALLEL_CONTRACTION_64O127GD
 
+// #include "../../definitons.h"
 #include "data_structure/hashed_graph.h"
 #include "data_structure/parallel_graph_access.h"
 #include "partition_config.h"
@@ -24,17 +25,17 @@ private:
         // compute mapping of labels id into contiguous intervall [0, ...., num_lables)
         void compute_label_mapping( MPI_Comm communicator, parallel_graph_access & G, 
                                     NodeID & global_num_distinct_ids,
-                                    std::unordered_map< NodeID, NodeID > & label_mapping);
+                                    extlib::unordered_map< NodeID, NodeID > & label_mapping);
 
         void get_nodes_to_cnodes_ghost_nodes( MPI_Comm communicator, parallel_graph_access & G );   
 
 	void build_quotient_graph_locally( parallel_graph_access & G, 
                                            NodeID number_of_distinct_labels, 
 					   hashed_graph & hG, 
-					   std::unordered_map< NodeID, NodeWeight > & node_weights);
+					   extlib::unordered_map< NodeID, NodeWeight > & node_weights);
 
         void redistribute_hased_graph_and_build_graph_locally( MPI_Comm communicator, hashed_graph &  hG, 
-                                                               std::unordered_map< NodeID, NodeWeight > & node_weights,
+                                                               extlib::unordered_map< NodeID, NodeWeight > & node_weights,
                                                                NodeID number_of_cnodes,
                                                                parallel_graph_access & Q);
 

--- a/parallel/parallel_src/lib/parallel_contraction_projection/parallel_projection.cpp
+++ b/parallel/parallel_src/lib/parallel_contraction_projection/parallel_projection.cpp
@@ -5,6 +5,7 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
+#include "definitions.h"
 #include "parallel_projection.h"
 
 parallel_projection::parallel_projection() {
@@ -25,7 +26,7 @@ void parallel_projection::parallel_project( MPI_Comm communicator, parallel_grap
 
         m_messages.resize(size);
 
-        std::unordered_map< NodeID, std::vector< NodeID > > cnode_to_nodes;
+        extlib::unordered_map< NodeID, std::vector< NodeID > > cnode_to_nodes;
         forall_local_nodes(finer, node) {
                 NodeID cnode = finer.getCNode(node);
                 //std::cout <<  "cnode " <<  cnode  << std::endl;

--- a/parallel/parallel_src/lib/parallel_label_compress/hmap_wrapper.h
+++ b/parallel/parallel_src/lib/parallel_label_compress/hmap_wrapper.h
@@ -8,6 +8,7 @@
 #ifndef HMAP_WRAPPER_RQFK3ARC
 #define HMAP_WRAPPER_RQFK3ARC
 
+#include "definitions.h"
 #include "data_structure/linear_probing_hashmap.h"
 
 template <typename T>
@@ -49,7 +50,7 @@ class hmap_wrapper < linear_probing_hashmap > {
 };
 
 template <>
-class hmap_wrapper <std::unordered_map<NodeID, NodeWeight> > {
+class hmap_wrapper <extlib::unordered_map<NodeID, NodeWeight> > {
         public:
 
                 hmap_wrapper(PPartitionConfig & config) {
@@ -63,7 +64,7 @@ class hmap_wrapper <std::unordered_map<NodeID, NodeWeight> > {
                 NodeWeight & operator[](NodeID node) {return mapping_type[node];};
 
         private:
-                std::unordered_map<NodeID, NodeWeight> mapping_type;
+                extlib::unordered_map<NodeID, NodeWeight> mapping_type;
                 PPartitionConfig m_config;
 };
 

--- a/parallel/parallel_src/lib/parallel_label_compress/parallel_label_compress.h
+++ b/parallel/parallel_src/lib/parallel_label_compress/parallel_label_compress.h
@@ -35,7 +35,7 @@ class parallel_label_compress {
                                 random_functions::permutate_vector_fast( permutation, true);
                         }
 
-                        //std::unordered_map<NodeID, NodeWeight> hash_map;
+                        //extlib::unordered_map<NodeID, NodeWeight> hash_map;
                         hmap_wrapper< T > hash_map(config);
                         hash_map.init( G.get_max_degree() );
                         for( ULONG i = 0; i < config.label_iterations; i++) {


### PR DESCRIPTION
Hi, after comparing recent benchmarks of popular hash map implementations such as
https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html and https://martin.ankerl.com/2019/04/01/hashmap-benchmarks-03-01-result-InsertHugeInt/ the winner for me is `robin_map` https://github.com/Tessil/robin-map due to general performance, being header-only, providing a close-to-std::unordered_map-API, and released under the MIT license. Google previously provided
https://github.com/sparsehash/sparsehash that is dated, a newer version is named `absl::flat_hash_map` https://github.com/abseil/abseil-cpp/blob/master/absl/container/flat_hash_map.h that is part of the absl library https://abseil.io/docs/cpp/guides/container and would make installing the entire library necessary to compile KaHIP which did not look ideal to me.

What i basically did in this PR is type-aliasing `extlib::unordered_map` as `robin_map` and replaced `std::unordered_map` with `extlib::unordered_map` in each and every project file except the occurrences in `misc/pymodule`. (The same applies to occasional occurrences of `std::unordered_set`).

This is just a starting point and must be seen as a first suggestion. What do you think about it? Wouldn't it be nice to write some unit tests to verify the correctness of the changes?

Best,
Daniel
