### PR TITLE
[ParHIP] Optimizations in parhip algorithm

### DIFF
--- a/parallel/parallel_src/lib/data_structure/balance_management_coarsening.cpp
+++ b/parallel/parallel_src/lib/data_structure/balance_management_coarsening.cpp
@@ -20,20 +20,15 @@ balance_management_coarsening::~balance_management_coarsening() {
 }
 
 void balance_management_coarsening::init(  ) {
+        m_fuzzy_block_weights.init((*m_G).number_of_local_nodes() + (*m_G).number_of_ghost_nodes());
+
         forall_local_nodes((*m_G), node) {
                 PartitionID label = m_G->getNodeLabel(node);
-                if( m_fuzzy_block_weights.find(label) == m_fuzzy_block_weights.end() ) {
-                        m_fuzzy_block_weights[label] = 0;
-                }
-
                 m_fuzzy_block_weights[label] += m_G->getNodeWeight(node);
         } endfor
 
         forall_ghost_nodes((*m_G),node) {
                 PartitionID label = m_G->getNodeLabel(node);
-                if( m_fuzzy_block_weights.find(label) == m_fuzzy_block_weights.end() ) {
-                        m_fuzzy_block_weights[label] = 0;
-                }
                 m_fuzzy_block_weights[label] += m_G->getNodeWeight(node);
         } endfor
 }

--- a/parallel/parallel_src/lib/data_structure/balance_management_coarsening.h
+++ b/parallel/parallel_src/lib/data_structure/balance_management_coarsening.h
@@ -9,6 +9,7 @@
 #define BALANCE_MANAGEMENT_COARSENING_TS6EZN5A
 
 #include "balance_management.h"
+#include "parallel_label_compress/hmap_wrapper.h"
 
 class parallel_graph_access;
 
@@ -25,7 +26,7 @@ public:
         virtual void update();
 
 private:
-        std::unordered_map< PartitionID, long > m_fuzzy_block_weights;
+        hmap_wrapper< std::unordered_map< PartitionID, NodeWeight> > m_fuzzy_block_weights;
 };
 
 
@@ -46,16 +47,8 @@ void balance_management_coarsening::setBlockSize( PartitionID block, NodeWeight 
 
 inline
 void balance_management_coarsening::update_non_contained_block_balance( PartitionID from, PartitionID to, NodeWeight node_weight) {
-        if( m_fuzzy_block_weights[from] == (long)node_weight) {
-                m_fuzzy_block_weights.erase(from);
-        } else {
-                m_fuzzy_block_weights[from] -= node_weight;
-        }
-        if( m_fuzzy_block_weights.find( to ) == m_fuzzy_block_weights.end() ) {
-                m_fuzzy_block_weights[to] = node_weight;
-        } else {
-                m_fuzzy_block_weights[to] += node_weight;
-        }
+        m_fuzzy_block_weights[from] -= node_weight;
+        m_fuzzy_block_weights[to] += node_weight;
 }
 
 #endif /* end of include guard: BALANCE_MANAGEMENT_COARSENING_TS6EZN5A */

--- a/parallel/parallel_src/lib/data_structure/linear_probing_hashmap.h
+++ b/parallel/parallel_src/lib/data_structure/linear_probing_hashmap.h
@@ -33,18 +33,16 @@ public:
                 m_real_size = m_size + max_size*1.1; // allow some slack in the end so that we do not need to handle special cases
 
                 m_internal_map.resize(m_real_size);
+                m_used.resize(m_real_size, NOT_CONTAINED);
+
+                CONTAINED_FLAG = NOT_CONTAINED - 1;
                 m_last_request = NOT_CONTAINED;
                 m_last_pos     = NOT_CONTAINED;
         }
 
         void clear() {
-                while( m_contained_key_positions.size() > 0 ) {
-                        NodeID cur_key_position = m_contained_key_positions.top();
-                        m_contained_key_positions.pop();
+                --CONTAINED_FLAG;
 
-                        m_internal_map[cur_key_position].key   = NOT_CONTAINED;
-                        m_internal_map[cur_key_position].value = 0;
-                }
                 m_last_request = NOT_CONTAINED;
         }
 
@@ -52,32 +50,32 @@ public:
         NodeID contains( NodeID node ) {
                 if( m_last_request == node ) return true;
                 NodeID hash_value = hash(node);
-                for( NodeID i = hash_value; i < m_real_size; i++) {
-                        if( m_internal_map[i].key == node || m_internal_map[i].key == NOT_CONTAINED) {
+                for( NodeID i = hash_value; i < m_real_size; ++i) {
+                        if( m_internal_map[i].key == node || m_used[i] != CONTAINED_FLAG ) {
                                 hash_value = i;
                                 break;
                         }
                 }
 
-                return m_internal_map[hash_value].key == node;
+                return m_internal_map[hash_value].key == node && m_used[hash_value] == CONTAINED_FLAG;
         }
 
         // find table position or the next free table position if it is not contained
-        NodeID find( NodeID node ) {
+        inline NodeID find( NodeID node ) {
                 if( m_last_request == node ) return m_last_pos;
 
                 NodeID hash_value = hash(node);
-                for( NodeID i = hash_value; i < m_real_size; i++) {
-                        if( m_internal_map[i].key == node || m_internal_map[i].key == NOT_CONTAINED) {
+                for( NodeID i = hash_value; i < m_real_size; ++i) {
+                        if( m_internal_map[i].key == node || m_used[i] != CONTAINED_FLAG ) {
                                 hash_value = i;
                                 break;
                         }
                 }
 
-                if( m_internal_map[hash_value].key == NOT_CONTAINED ) {
+                if( m_used[hash_value] != CONTAINED_FLAG ) {
+                        m_used[hash_value] = CONTAINED_FLAG;
                         m_internal_map[hash_value].key = node;
                         m_internal_map[hash_value].value = 0;
-                        m_contained_key_positions.push(hash_value);
                 }
 
                 m_last_request = node;
@@ -96,12 +94,14 @@ public:
 
         std::vector< KeyValuePair > * internal_access() {return & m_internal_map; }
 private:
+        NodeID CONTAINED_FLAG = NOT_CONTAINED;
+
         NodeID m_size; 
         NodeID m_real_size; 
         NodeID m_last_pos;
         NodeID m_last_request;
         std::vector< KeyValuePair > m_internal_map;
-        std::stack< NodeID > m_contained_key_positions;
+        std::vector< NodeID > m_used;
 };
 
 

--- a/parallel/parallel_src/lib/data_structure/parallel_graph_access.h
+++ b/parallel/parallel_src/lib/data_structure/parallel_graph_access.h
@@ -10,6 +10,7 @@
 
 
 #include <mpi.h>
+#include <algorithm>
 #include <unordered_map>
 #include <iostream>
 #include <ostream>
@@ -266,11 +267,9 @@ public:
         };
 
         PEID get_PEID_from_range_array(NodeID node) {
-                // TODO optimize with binary search
-                for( PEID peID = 1; peID < (PEID)m_range_array.size(); peID++) {
-                        if( node < m_range_array[peID] ) {
-                                return (peID-1);
-                        }
+                auto it = std::upper_bound(m_range_array.begin() + 1, m_range_array.end(), node);
+                if (it != m_range_array.end()) {
+                        return it - m_range_array.begin() - 1;
                 }
                 return -1;
         };

--- a/parallel/parallel_src/lib/parallel_label_compress/hmap_wrapper.h
+++ b/parallel/parallel_src/lib/parallel_label_compress/hmap_wrapper.h
@@ -9,11 +9,11 @@
 #define HMAP_WRAPPER_RQFK3ARC
 
 #include "data_structure/linear_probing_hashmap.h"
+#include "partition_config.h"
 
 template <typename T>
 class hmap_wrapper {
         public:
-
                 hmap_wrapper(PPartitionConfig & config) {
                         m_config = config;
                 };
@@ -32,7 +32,6 @@ private:
 template <>
 class hmap_wrapper < linear_probing_hashmap > {
         public:
-
                 hmap_wrapper(PPartitionConfig & config) {
                         m_config = config;
                 };
@@ -51,18 +50,47 @@ class hmap_wrapper < linear_probing_hashmap > {
 template <>
 class hmap_wrapper <std::unordered_map<NodeID, NodeWeight> > {
         public:
-
+                hmap_wrapper() {
+                };
                 hmap_wrapper(PPartitionConfig & config) {
                         m_config = config;
                 };
 
                 virtual ~hmap_wrapper() {};
 
-                void init( NodeID max_fill_count )  {};
-                void clear() { mapping_type.clear(); };
-                NodeWeight & operator[](NodeID node) {return mapping_type[node];};
+                void init(NodeID max_fill_count )  {
+                        mapping_type.clear();
+                        mapping_type.reserve(max_fill_count);
+                        mapping_type_small.assign(max_fill_count, 0);
+                        small_thresold = max_fill_count;
+                };
+                void clear() { 
+                        mapping_type.clear(); 
+                        while (mapping_type_small.size() > small_thresold) {
+                                mapping_type_small[mapping_type_small.back()] = 0;
+                                mapping_type_small.pop_back();
+                        }
+                };
+                NodeWeight & operator[](NodeID node) {
+                        if (node < small_thresold) {
+                                if (!mapping_type_small[node]) {
+                                        mapping_type_small.emplace_back(node);
+                                }
+                                return mapping_type_small[node];
+                        }
+                        return mapping_type[node];
+                };
+                void erase(NodeID node) {
+                        if (node < small_thresold) {
+                                mapping_type_small[node] = 0;
+                                return;
+                        }
+                        mapping_type.erase(node);
+                }
 
         private:
+                size_t small_thresold;
+                std::vector<NodeWeight> mapping_type_small;
                 std::unordered_map<NodeID, NodeWeight> mapping_type;
                 PPartitionConfig m_config;
 };

--- a/parallel/parallel_src/lib/parallel_label_compress/node_ordering.h
+++ b/parallel/parallel_src/lib/parallel_label_compress/node_ordering.h
@@ -92,17 +92,11 @@ public:
         }
 
         void order_leastghostnodes_nodes_degree(const PPartitionConfig & config, parallel_graph_access & G, std::vector< NodeID > & ordered_nodes) { 
-                std::sort( ordered_nodes.begin(), ordered_nodes.end(), 
-                           [&]( const NodeID & lhs, const NodeID & rhs) -> bool {
-                                return (G.getNodeDegree(lhs) < G.getNodeDegree(rhs));
-                           });
+                order_nodes_degree(config, G, ordered_nodes);
         }
 
 	void order_nodes_degree_leastghostnodes(const PPartitionConfig & config, parallel_graph_access & G, std::vector< NodeID > & ordered_nodes) { 
-                std::sort( ordered_nodes.begin(), ordered_nodes.end(), 
-                           [&]( const NodeID & lhs, const NodeID & rhs) -> bool {
-				return (G.getNodeDegree(lhs) < G.getNodeDegree(rhs));
-                           });
+                order_nodes_degree(config, G, ordered_nodes);
         }
 };
 


### PR DESCRIPTION
This PR adds some optimization in parhip algorithm.

Reduced working time of full algorithm by **~2%**. 

Here are main points of this PR:

- Optimized access to **m_fuzzy_block_weights** map by adding vector for small values
- Optimized **linear_probing_hashmap**. Now **clear** method works in **O(1)** instead of **O(|distinct keys|)**
- Added counting sort in node ordering functions (in sparse graphs difference can be more noticeable)
- Solved one TODO. Replaced linear search in getting PEID function with **upper_bound**
