### PR TITLE
Drop extraneous semicolons

### DIFF
--- a/lib/data_structure/flow_graph.h
+++ b/lib/data_structure/flow_graph.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * flow_graph.h 
+ * flow_graph.h
  * *
  * Source of KaHIP -- Karlsruhe High Quality Partitioning.
  * Christian Schulz <christian.schulz.phone@gmail.com>
@@ -44,7 +44,7 @@ public:
                 m_num_nodes = nodes;
                 m_num_edges = edges;
         }
- 
+
         void finish_construction() {};
 
         NodeID number_of_nodes() {return m_num_nodes;};
@@ -57,7 +57,7 @@ public:
         void setEdgeFlow(NodeID source, EdgeID e, FlowType flow);
 
         EdgeID getReverseEdge(NodeID source, EdgeID e);
-        
+
         void new_edge(NodeID source, NodeID target, FlowType capacity) {
                m_adjacency_lists[source].push_back(rEdge(source, target, capacity, 0, m_adjacency_lists[target].size()));
                // for each edge we add a reverse edge
@@ -78,45 +78,45 @@ private:
 inline
 NodeID flow_graph::getEdgeCapacity(NodeID source, EdgeID e) {
 #ifdef NDEBUG
-        return m_adjacency_lists[source][e].capacity;        
+        return m_adjacency_lists[source][e].capacity;
 #else
-        return m_adjacency_lists.at(source).at(e).capacity;        
+        return m_adjacency_lists.at(source).at(e).capacity;
 #endif
-};
+}
 
 inline
 void flow_graph::setEdgeFlow(NodeID source, EdgeID e, FlowType flow) {
 #ifdef NDEBUG
-        m_adjacency_lists[source][e].flow = flow;        
+        m_adjacency_lists[source][e].flow = flow;
 #else
-        m_adjacency_lists.at(source).at(e).flow = flow;        
+        m_adjacency_lists.at(source).at(e).flow = flow;
 #endif
-};
+}
 
 inline
 FlowType flow_graph::getEdgeFlow(NodeID source, EdgeID e) {
 #ifdef NDEBUG
-        return m_adjacency_lists[source][e].flow;        
+        return m_adjacency_lists[source][e].flow;
 #else
-        return m_adjacency_lists.at(source).at(e).flow;        
+        return m_adjacency_lists.at(source).at(e).flow;
 #endif
-};
+}
 
 inline
 NodeID flow_graph::getEdgeTarget(NodeID source, EdgeID e) {
 #ifdef NDEBUG
-        return m_adjacency_lists[source][e].target;        
+        return m_adjacency_lists[source][e].target;
 #else
-        return m_adjacency_lists.at(source).at(e).target;        
+        return m_adjacency_lists.at(source).at(e).target;
 #endif
-};
+}
 
 inline
 EdgeID flow_graph::getReverseEdge(NodeID source, EdgeID e) {
 #ifdef NDEBUG
         return m_adjacency_lists[source][e].reverse_edge_index;
 #else
-        return m_adjacency_lists.at(source).at(e).reverse_edge_index;        
+        return m_adjacency_lists.at(source).at(e).reverse_edge_index;
 #endif
 
 }

--- a/lib/data_structure/priority_queues/maxNodeHeap.h
+++ b/lib/data_structure/priority_queues/maxNodeHeap.h
@@ -97,11 +97,11 @@ class maxNodeHeap : public priority_queue_interface {
 
 inline Gain maxNodeHeap::maxValue() {
         return m_heap[0].first;
-};
+}
 
 inline NodeID maxNodeHeap::maxElement() {
         return m_elements[m_heap[0].second].get_data().node;
-};
+}
 
 inline void maxNodeHeap::siftDown( int pos ) {
 
@@ -214,7 +214,7 @@ inline void maxNodeHeap::deleteNode(NodeID node) {
                 siftDown(heap_index);
                 siftUp(heap_index);
         }
-};
+}
 
 inline NodeID maxNodeHeap::deleteMax() {
         if( m_heap.size() > 0) {
@@ -255,7 +255,7 @@ inline void maxNodeHeap::changeKey(NodeID node, Gain gain) {
         } else if ( old_gain < gain ) {
                 increaseKey(node, gain);
         }
-};
+}
 
 inline void maxNodeHeap::decreaseKey(NodeID node, Gain gain) {
         ASSERT_TRUE(m_element_index.find(node) != m_element_index.end());
@@ -277,8 +277,7 @@ inline void maxNodeHeap::increaseKey(NodeID node, Gain gain) {
 
 inline Gain maxNodeHeap::getKey(NodeID node) {
         return m_heap[m_elements[m_element_index[node]].get_index()].first;
-};
-
+}
 
 inline bool maxNodeHeap::contains(NodeID node) {
        return m_element_index.find(node) != m_element_index.end();


### PR DESCRIPTION
Also trims trailing whitespace (it might be good for you to make a commit which does this for all files as trailing whitespace tends to make PRs noisier and, for that reason, most editors include an option to automatically remove it when a file is saved).