### PR TITLE
Use pybind11_add_module() to build Python interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(KaHIP C CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -42,7 +42,7 @@ if(COMPILER_SUPPORTS_WALL)
 endif()
 CHECK_CXX_COMPILER_FLAG(-march=native COMPILER_SUPPORTS_MARCH_NATIVE)
 if(COMPILER_SUPPORTS_MARCH_NATIVE)
-  if( NOT NONATIVEOPTIMIZATIONS ) 
+  if( NOT NONATIVEOPTIMIZATIONS )
           add_definitions(-march=native)
   endif()
 endif()
@@ -202,7 +202,7 @@ add_library(libmapping OBJECT ${LIBMAPPING_SOURCE_FILES})
 set(LIBSPAC_SOURCE_FILES lib/spac/spac.cpp)
 add_library(libspac OBJECT ${LIBSPAC_SOURCE_FILES})
 
-set(NODE_ORDERING_SOURCE_FILES 
+set(NODE_ORDERING_SOURCE_FILES
   lib/node_ordering/min_degree_ordering.cpp
   lib/node_ordering/nested_dissection.cpp
   lib/node_ordering/ordering_tools.cpp
@@ -321,7 +321,7 @@ if(LIB_METIS)
         target_link_libraries(interface_static PUBLIC ${LIB_METIS})
 endif()
 
-install(TARGETS interface_static 
+install(TARGETS interface_static
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         PUBLIC_HEADER DESTINATION include
@@ -348,4 +348,10 @@ if(USE_ILP)
 
 endif()
 
-
+# pybind11 module
+option(BUILDPYTHONMODULE "Build Python binding." OFF)
+if (BUILDPYTHONMODULE)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/misc/pymodule/pybind11)
+  pybind11_add_module(kahip_python_binding ${CMAKE_CURRENT_SOURCE_DIR}/misc/pymodule/kahip.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping>)
+  set_target_properties(kahip_python_binding PROPERTIES OUTPUT_NAME "kahip")
+endif ()

--- a/compile_withcmake.sh
+++ b/compile_withcmake.sh
@@ -15,7 +15,7 @@ rm -rf build
 mkdir build
 cd build
 if [ "$1" == "BUILDPYTHONMODULE" ]; then
-cmake ../ -DCMAKE_BUILD_TYPE=Release 
+cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILDPYTHONMODULE=On
 else 
 cmake ../ -DCMAKE_BUILD_TYPE=Release $1
 fi
@@ -68,12 +68,8 @@ cp ./build/parallel/modified_kahip/lib*.a deploy/parallel/libkahip.a
 
 # maybe adapt paths here and python version here
 if [ "$1" == "BUILDPYTHONMODULE" ]; then
-cd misc/pymodule/
-PYTHONINCLUDEPATH=`python3 -c "from sysconfig import get_paths as gp; print(gp()['include'])"`
-g++ -O3 -Wall -shared -std=c++11 -fPIC `python3 -m pybind11 --includes` kahip.cpp -L../../deploy/ -lkahip -o kahip`python3-config --extension-suffix` -Ipybind11/include -I$PYTHONINCLUDEPATH
-cd ..; cd ..;
 cp misc/pymodule/call* deploy/
-cp misc/pymodule/kahip.cp* deploy/
+cp ./build/kahip.cp* deploy/
 fi
 
 

--- a/misc/pymodule/kahip.cpp
+++ b/misc/pymodule/kahip.cpp
@@ -1,5 +1,5 @@
 #include <pybind11/pybind11.h>
-#include "../../interface/kaHIP_interface.h"
+#include "interface/kaHIP_interface.h"
 
 pybind11::object wrap_kaffpa(
                 const pybind11::object &vwgt,


### PR DESCRIPTION
I think that this is a more robust and idiomatic approach at building the Python interface. In particular, it also works on macOS. 