### PR TITLE
ENH: disable MPI detection (pointless) if ParHIP itself is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,7 @@ if(COMPILER_SUPPORTS_NOSIGNCOMP)
 endif()
 
 
-
-# check dependencies
-find_package(MPI REQUIRED)
+# Check dependencies
 find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
   message(STATUS "OpenMP support detected")
@@ -92,14 +90,32 @@ if(OPTIMIZED_OUTPUT)
   add_definitions("-DKAFFPAOUTPUT")
 endif()
 
+
 # ParHIP
 option(PARHIP "build ParHIP" ON)
+
+if(PARHIP)
+  message(STATUS "ParHIP build requested")
+  find_package(MPI REQUIRED)
+else()
+  message(STATUS "ParHIP build disabled")
+endif()
+
+# Report which MPI we actually found,
+# may need use MPI_HOME hint to get the proper one (eg, on openSUSE)
+#
+if(${MPI_C_FOUND})
+message("MPI detected (can use MPI_HOME hint to direct the detection...)")
+message(STATUS "MPI include: ${MPI_C_INCLUDE_DIRS}")
+message(STATUS "MPI library: ${MPI_C_LIBRARIES}")
+endif()
+
 
 # tcmalloc
 option(USE_TCMALLOC "if available, link against tcmalloc" OFF)
 
 
-# ILP improver 
+# ILP improver
 option(USE_ILP "build local ILP improver - introduces dependency on Gurobi" OFF)
 
 


### PR DESCRIPTION
- when MPI is detected, report the include and library information.

  On systems with multiple MPI installations, the cmake find MPI
  follows a fixed order, irrespective of the current user environment.

  On openSUSE (for example), this means it will detect libmpich first
  and use that for linking, even if the environment is nominally
  using open-mpi. At runtime there will be a ldd so version mismatch
  and it will bail.

  Better to inform people up-front about what they are actually
  getting and mention the existence of the MPI_HOME env variable
  which can be used to influence the cmake find MPI.