### PR TITLE
Add missing USE_OPENMP and apple clang support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ find_library(LIB_METIS metis)
 if(LIB_METIS)
   message(STATUS "Metis support detected")
   add_definitions("-DUSEMETIS")
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    include_directories(/usr/local/include)
+  endif()
 endif()
 
 # 64 Bit option
@@ -273,7 +276,7 @@ install(TARGETS interface_test DESTINATION bin)
 add_executable(kaffpaE app/kaffpaE.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping> $<TARGET_OBJECTS:libkaffpa_parallel>)
 target_compile_definitions(kaffpaE PRIVATE "-DMODE_KAFFPAE")
 target_include_directories(kaffpaE PUBLIC ${MPI_CXX_INCLUDE_PATH})
-target_link_libraries(kaffpaE ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
+target_link_libraries(kaffpaE ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} OpenMP::OpenMP_CXX )
 install(TARGETS kaffpaE DESTINATION bin)
 
 add_executable(graphchecker app/graphchecker.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping>)

--- a/app/kaffpaE.cpp
+++ b/app/kaffpaE.cpp
@@ -26,6 +26,7 @@
 #include "quality_metrics.h"
 #include "random_functions.h"
 #include "timer.h"
+#include <omp.h>
 
 int main(int argn, char **argv) {
 

--- a/app/parse_parameters.h
+++ b/app/parse_parameters.h
@@ -8,8 +8,9 @@
 
 #ifndef PARSE_PARAMETERS_GPJMGSM8
 #define PARSE_PARAMETERS_GPJMGSM8
-
+#ifdef USE_OPENMP
 #include <omp.h>
+#endif
 #include <string>
 #include <sstream>
 #include "configuration.h"

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.cpp
@@ -4,9 +4,9 @@
  * Source of KaHIP -- Karlsruhe High Quality Partitioning.
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
-
+#ifdef USE_OPENMP
 #include <omp.h>
-
+#endif
 #include "kway_graph_refinement_commons.h"
 
 kway_graph_refinement_commons::kway_graph_refinement_commons( PartitionConfig & config ) {

--- a/parallel/modified_kahip/app/parse_parameters.h
+++ b/parallel/modified_kahip/app/parse_parameters.h
@@ -8,8 +8,9 @@
 
 #ifndef PARSE_PARAMETERS_GPJMGSM8
 #define PARSE_PARAMETERS_GPJMGSM8
-
+#ifdef USE_OPENMP
 #include <omp.h>
+#endif
 #include "configuration.h"
 
 int parse_parameters(int argn, char **argv, 


### PR DESCRIPTION
Hello,

In this pull-request the support for apple clang on mac os is addressed.

**Current Behaviour**

 Currently compilation on MacOS fails due to missing include guards around `#include <omp.h>`.

**Changes**

I added these guards in order to make non openmp targets compile on mac os. I added one include in `kaffpaE.cpp` as it is required to have omp support. Furthermore, I adapted the `CMakeLists.txt` to find metis headers on Mac.

Best,

Henrik


