### PR TITLE
Lower CMake version and limit parallelism in compile script

### DIFF
--- a/compile_withcmake.sh
+++ b/compile_withcmake.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 cd "${0%/*}" || exit  # Run from current directory (source directory) or exit
 
-case "$(uname)" in
-Darwin)
-    NCORES=$(sysctl -n hw.ncpu)
-    ;;
-*)
-    NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
-    ;;
-esac
-[ -n "$NCORES" ] || NCORES=4
+if [[ -z "$NCORES" ]]; then 
+    case "$(uname)" in
+        Darwin)
+            NCORES=$(sysctl -n hw.ncpu)
+            ;;
+        *)
+            NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+            ;;
+    esac
+    [ -n "$NCORES" ] || NCORES=4
+fi
 
 rm -rf deploy
 rm -rf build

--- a/compile_withcmake.sh
+++ b/compile_withcmake.sh
@@ -16,11 +16,14 @@ rm -rf build
 mkdir build
 
 if [ "$1" == "BUILDPYTHONMODULE" ]; then
-    cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILDPYTHONMODULE=On
-else
-    cmake -B build -S . -DCMAKE_BUILD_TYPE=Release $1
+    ADDITIONAL_ARGS="-DBUILDPYTHONMODULE=On"
+else 
+    ADDITIONAL_ARGS="$1"
 fi
-(cd build && make -j $NCORES)
+
+(cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release $ADDITIONAL_ARGS && \
+    make -j $NCORES)
 
 echo
 echo "Copying files into 'deploy'"

--- a/compile_withcmake.sh
+++ b/compile_withcmake.sh
@@ -24,7 +24,7 @@ else
 fi
 
 (cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release $ADDITIONAL_ARGS && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release "$ADDITIONAL_ARGS" && \
     make -j $NCORES)
 
 echo


### PR DESCRIPTION
Addresses #107:

- Remove `cmake -B` to allow CMake versions lower than 3.13 

- Only detect and use number of available cores if `NCORES` is not set as an environment variable