### PR TITLE
Remove use of deprecated std::binary_function

### DIFF
--- a/lib/partition/coarsening/matching/gpa/compare_rating.h
+++ b/lib/partition/coarsening/matching/gpa/compare_rating.h
@@ -11,7 +11,7 @@
 #include "data_structure/graph_access.h"
 #include "definitions.h"
 
-class compare_rating : public std::binary_function<EdgeRatingType, EdgeRatingType, bool> {
+class compare_rating {
         public:
                 compare_rating(graph_access * pG) : G(pG) {};
                 virtual ~compare_rating() {};

--- a/parallel/modified_kahip/lib/partition/coarsening/matching/gpa/compare_rating.h
+++ b/parallel/modified_kahip/lib/partition/coarsening/matching/gpa/compare_rating.h
@@ -11,7 +11,7 @@
 #include "data_structure/graph_access.h"
 #include "definitions.h"
 
-class compare_rating : public std::binary_function<EdgeRatingType, EdgeRatingType, bool> {
+class compare_rating {
         public:
                 compare_rating(graph_access * pG) : G(pG) {};
                 virtual ~compare_rating() {};


### PR DESCRIPTION
`std::binary_function` is deprecated since C++11 and got removed in C++17. Recent GCC versions output a warning about it.

Since we're not using any of the types defined by `std::binary_function` it seems as if we could just remove it. 