### PR TITLE
Make kahip findable with pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
+set(KAHIP_VERSION 3.15)
+
 include(CheckCXXCompilerFlag)
+include(GNUInstallDirs)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_program(CCACHE_PROGRAM ccache)
@@ -340,6 +343,11 @@ if(LIB_METIS)
         target_link_libraries(kahip PUBLIC ${LIB_METIS})
 endif()
 install(TARGETS kahip DESTINATION lib)
+
+# pkg-config
+configure_file("lib/kahip.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/kahip.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kahip.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
 
 # Static interface library
 add_library(kahip_static interface/kaHIP_interface.cpp $<TARGET_OBJECTS:libkaffpa>

--- a/lib/kahip.pc.in
+++ b/lib/kahip.pc.in
@@ -1,0 +1,15 @@
+#   KaHIP - Karlsruhe HIGH Quality Partitioning
+#   Copyright (c) 2019 <christian.schulz.phone@gmail.com>
+#   MIT license (https://opensource.org/license/mit)
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: kahip
+Description: The graph partitioning framework KaHIP
+URL: https://kahip.github.io/
+Version: @KAHIP_VERSION@
+Libs: -L${libdir} -lkahip
+Cflags: -I${includedir}

--- a/parallel/parallel_src/CMakeLists.txt
+++ b/parallel/parallel_src/CMakeLists.txt
@@ -107,6 +107,11 @@ install(TARGETS parhip_interface
         PUBLIC_HEADER DESTINATION include
         )
 
+# pkg-config
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/parhip_interface.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/parhip_interface.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/parhip_interface.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+
 add_library(parhip_interface_static interface/parhip_interface.cpp $<TARGET_OBJECTS:libparallel>)
 target_compile_definitions(parhip_interface_static PRIVATE "-DGRAPH_GENERATOR_MPI -DGRAPHGEN_DISTRIBUTED_MEMORY -DPARALLEL_LABEL_COMPRESSION")
 target_include_directories(parhip_interface_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/interface)

--- a/parallel/parallel_src/parhip_interface.pc.in
+++ b/parallel/parallel_src/parhip_interface.pc.in
@@ -1,0 +1,15 @@
+#   ParHIP - Parallel High Quality Partitioning
+#   Copyright (c) 2019 <christian.schulz.phone@gmail.com>
+#   MIT license (https://opensource.org/license/mit)
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: parhip_interface
+Description: distributed memory parallel partitioning techniques
+URL: https://kahip.github.io/
+Version: @KAHIP_VERSION@
+Libs: -L${libdir} -lparhip_interface
+Cflags: -I${includedir}


### PR DESCRIPTION
With this PR, one can find kahip using pkg-config.
I don't know much about cmake or pkg-config, so I'm not sure if it is perfect, but it seems to work.