### PR TITLE
[KaHIP Interface - Process Mapping] bug fix + partition update after mapping 

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Project Contributors (sorted by last name)
 =====
 Yaroslav Akhremtsev
 
+Adil Chhabra
+
 Marcelo Fonseca Faraj
 
 Roland Glantz

--- a/interface/kaHIP_interface.cpp
+++ b/interface/kaHIP_interface.cpp
@@ -596,6 +596,8 @@ void internal_processmapping_call(PartitionConfig & partition_config,
 
         forall_nodes(G, node) {
                 G.setPartitionIndex(node, perm_rank[G.getPartitionIndex(node)]);
+                // update part IDs after mapping algorithm
+                part[node] = G.getPartitionIndex(node);
         } endfor
 
         *qap = (int)internal_qap;
@@ -645,6 +647,11 @@ void process_mapping(int* n, int* vwgt, int* xadj,
         for( int i = 0; i < hierarchy_depth; i++) {
                 partition_config.group_sizes.push_back(hierarchy_parameter[i]);
                 partition_config.distances.push_back(distance_parameter[i]);
+        }
+
+        // compute k 
+        for( unsigned int i = 0; i < partition_config.group_sizes.size(); i++) {
+                partition_config.k *= partition_config.group_sizes[i];
         }
 
         partition_config.seed = seed;


### PR DESCRIPTION
Description: 

- The process_mapping function in the KaHIP Interface returned partition IDs for all nodes before the mapping algorithm recomputed the partition indices. This has now been fixed.

- Additionally, partition_config.k was not computed in the process_mapping function in the KaHIP Interface, and was simply set to 1. Now, the value of partition_config.k is computed as a multiple of group sizes of partitions in the heirarchy (as required). This fixes another bug pertaining to the vector 'perm_rank' used by the mapping algorithms which is initialized to the size of partition_config.k. After this fix, calls to mapping algorithms from the KaHIP Interface work correctly, and so does the computation of the total_qap score. 

NOTE: These bugs only exist in the KaHIP Interface, and not in the global_multisection app. 