### PR TITLE
Support weights in edge partitioning

### DIFF
--- a/interface/kaHIP_interface.cpp
+++ b/interface/kaHIP_interface.cpp
@@ -662,7 +662,7 @@ void process_mapping(int* n, int* vwgt, int* xadj,
 void edge_partitioning(int* n, int* vwgt, int* xadj, 
                    int* adjcwgt, int* adjncy, int* nparts, 
                    double* imbalance, bool suppress_output, int seed, int mode, 
-                   int* vertexcut, int* part) {
+                   int* vertexcut, int* part, int infinity_edge_weight) {
         configuration cfg;
         PartitionConfig partition_config;
         partition_config.k = *nparts;
@@ -675,7 +675,7 @@ void edge_partitioning(int* n, int* vwgt, int* xadj,
         graph_access G;     
         internal_build_graph( partition_config, n, vwgt, xadj, adjcwgt, adjncy, G);
 
-        spac splitter(G, 1000);
+        spac splitter(G, infinity_edge_weight);
         graph_access &split_G = splitter.construct_split_graph();
 
         balance_configuration bc;

--- a/interface/kaHIP_interface.h
+++ b/interface/kaHIP_interface.h
@@ -72,7 +72,8 @@ void reduced_nd(int* n, int* xadj, int* adjncy,
 void edge_partitioning(int* n, int* vwgt, int* xadj, 
                    int* adjcwgt, int* adjncy, int* nparts, 
                    double* imbalance, bool suppress_output, int seed, int mode, 
-                   int* vertexcut, int* part);
+                   int* vertexcut, int* part, int infinity_edge_weight = 1000);
+
 #ifdef USEMETIS
 // reduced nested dissection with metis
 void reduced_nd_fast(int* n, int* xadj, int* adjncy,

--- a/lib/spac/spac.h
+++ b/lib/spac/spac.h
@@ -23,7 +23,7 @@ public:
 
     std::vector<PartitionID> project_partition();
 
-    unsigned calculate_vertex_cut(const std::vector<PartitionID> &edge_partition);
+    unsigned long calculate_vertex_cut(const std::vector<PartitionID> &edge_partition);
 
 private:
     void find_reverse_edges();


### PR DESCRIPTION
Currently, the edge partitioning code ignores vertex and edge weights. This PR adds rudimentary support, **but**: for weighted input graphs, it might be harder to find "good" values for the "infinity" edge weight of dominant edges, i.e., one that is respected by the vertex partitioner and does not cause overflows. Contracting the dominant edges as in @adilchhabra 's code would be a much better option; maybe we should integrate his code instead? Would that be a lot of work or just plug'n'play? What do you think Adil? 