### PR TITLE
Distributed SPAC: fix edge partition order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,11 @@ target_compile_definitions(evaluator PRIVATE "-DMODE_EVALUATOR")
 target_link_libraries(evaluator ${OpenMP_CXX_LIBRARIES})
 install(TARGETS evaluator DESTINATION bin)
 
+add_executable(edge_evaluator app/edge_evaluator.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping>)
+target_compile_definitions(edge_evaluator PRIVATE "-DMODE_EVALUATOR")
+target_link_libraries(edge_evaluator ${OpenMP_CXX_LIBRARIES})
+install(TARGETS edge_evaluator DESTINATION bin)
+
 add_executable(node_separator app/node_separator_ml.cpp $<TARGET_OBJECTS:libkaffpa> $<TARGET_OBJECTS:libmapping>)
 target_compile_definitions(node_separator PRIVATE "-DMODE_NODESEP")
 target_link_libraries(node_separator ${OpenMP_CXX_LIBRARIES})

--- a/app/edge_evaluator.cpp
+++ b/app/edge_evaluator.cpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * evaluator.cpp
+ * *
+ * Source of KaHIP -- Karlsruhe High Quality Partitioning.
+ * Daniel Seemaier <daniel.seemaier@kit.edu>
+ *****************************************************************************/
+
+#include <argtable3.h>
+#include <regex.h>
+#include <string.h>
+
+#include "data_structure/graph_access.h"
+#include "graph_io.h"
+#include "parse_parameters.h"
+#include "partition/partition_config.h"
+#include "quality_metrics.h"
+
+int main(int argn, char **argv) {
+    PartitionConfig partition_config;
+    std::string graph_filename;
+
+    bool is_graph_weighted = false;
+    bool suppress_output = false;
+    bool recursive = false;
+
+    int ret_code =
+        parse_parameters(argn, argv, partition_config, graph_filename,
+                         is_graph_weighted, suppress_output, recursive);
+
+    if (ret_code) {
+        return 0;
+    }
+
+    graph_access G;
+    graph_io::readGraphWeighted(G, graph_filename);
+    G.set_partition_count(partition_config.k);
+
+    std::vector<EdgeID> edge_partition(G.number_of_edges());
+
+    std::vector<PartitionID> input_partition;
+    if (partition_config.input_partition != "") {
+        std::cout << "reading input partition" << std::endl;
+        graph_io::readVector(edge_partition, partition_config.input_partition);
+    } else {
+        std::cout << "Please specify an input partition using the "
+                     "--input_partition flag."
+                  << std::endl;
+        exit(0);
+    }
+
+    std::cout << "graph has " << G.number_of_nodes() << " nodes and "
+              << G.number_of_edges() << " edges" << std::endl;
+
+    for (NodeID u = 0; u < G.number_of_nodes(); ++u) {
+        for (EdgeID e = G.get_first_edge(u); e < G.get_first_invalid_edge(u);
+             ++e) {
+            NodeID v = G.getEdgeTarget(e);
+            for (EdgeID e_prime = G.get_first_edge(v);
+                 e_prime < G.get_first_invalid_edge(v); ++e_prime) {
+                if (G.getEdgeTarget(e_prime) == u) {
+                    PartitionID part = edge_partition[e];
+                    PartitionID part_prime = edge_partition[e_prime];
+                    if (part != part_prime) {
+                        std::cerr << "edge (" << u << ", " << v
+                                  << ") has different partitions: " << part
+                                  << " and " << part_prime << std::endl;
+                        std::exit(1);
+                    }
+                }
+            }
+        }
+    }
+
+    unsigned cost = 0;
+    std::vector<bool> counted(G.get_partition_count());
+    for (NodeID u = 0; u < G.number_of_nodes(); ++u) {
+        if (G.getNodeDegree(u) == 0) continue;
+
+        for (EdgeID e = G.get_first_edge(u); e < G.get_first_invalid_edge(u);
+             ++e) {
+            PartitionID part = edge_partition[e];
+            if (!counted[part]) {
+                counted[part] = true;
+                ++cost;
+            }
+        }
+
+        --cost;
+        std::fill(counted.begin(), counted.end(), false);
+    }
+
+    std::cout << "vertex cut: " << cost << std::endl;
+
+    quality_metrics qm;
+    std::cout << "balance: " << qm.edge_balance(G, edge_partition) << std::endl;
+}
+

--- a/parallel/parallel_src/lib/dspac/dspac.cpp
+++ b/parallel/parallel_src/lib/dspac/dspac.cpp
@@ -389,12 +389,12 @@ bool dspac::assert_node_range_array_ok(const std::vector<NodeID> &node_range_arr
     return true;
 }
 
-std::vector<PartitionID> dspac::project_partition(parallel_graph_access &split_graph) {
+std::vector<PartitionID> dspac::project_partition(parallel_graph_access &split_graph, const std::vector<EdgeID> &permutation) {
     std::vector<PartitionID> edge_partition(m_input_graph.number_of_local_edges());
 
     for (NodeID v = 0; v < m_input_graph.number_of_local_nodes(); ++v) {
         for (EdgeID e = m_input_graph.get_first_edge(v); e < m_input_graph.get_first_invalid_edge(v); ++e) {
-            edge_partition[e] = split_graph.getNodeLabel(e);
+            edge_partition[permutation[e]] = split_graph.getNodeLabel(e);
         }
     }
 

--- a/parallel/parallel_src/lib/dspac/dspac.h
+++ b/parallel/parallel_src/lib/dspac/dspac.h
@@ -17,7 +17,7 @@ class dspac {
 public:
     dspac(parallel_graph_access &graph, MPI_Comm comm, EdgeWeight infinity);
     void construct(parallel_graph_access &split_graph);
-    std::vector<PartitionID> project_partition(parallel_graph_access &split_graph);
+    std::vector<PartitionID> project_partition(parallel_graph_access &split_graph, const std::vector<EdgeID> &permutation);
     EdgeWeight calculate_vertex_cut(PartitionID k, const std::vector<PartitionID> &edge_partition);
     void fix_cut_dominant_edges(parallel_graph_access &split_graph);
 

--- a/parallel/parallel_src/lib/dspac/edge_balanced_graph_io.h
+++ b/parallel/parallel_src/lib/dspac/edge_balanced_graph_io.h
@@ -18,10 +18,10 @@
 class edge_balanced_graph_io {
 public:
     static void read_binary_graph_edge_balanced(parallel_graph_access &G, const std::string &filename,
-            const PPartitionConfig &config, int rank, int size);
+            const PPartitionConfig &config, std::vector<EdgeID> &permutation, int rank, int size);
 
     static void read_binary_graph_edge_balanced(parallel_graph_access &G, const std::string &filename,
-            const PPartitionConfig &config);
+            const PPartitionConfig &config, std::vector<EdgeID> &permutation);
 };
 
 #endif // KAHIP_EDGEBALANCED_GRAPH_IO_H


### PR DESCRIPTION
dSPAC sorts the neighborhoods of vertices during IO, but does not revert to the original edge order when outputting the edge partition. This PR fixes that (and also adds a tool to evaluate the partition file). 