### PR TITLE
Fix cibuildwheel 429 rate-limit on macOS

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,6 +37,7 @@ jobs:
           # Skip 32-bit builds and musllinux for now
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           # Pass CMake arguments for building Python module
+          CIBW_DEPENDENCY_VERSIONS: "pinned"
           CIBW_ENVIRONMENT: >
             CMAKE_ARGS="-DBUILDPYTHONMODULE=ON -DNOMPI=ON"
 


### PR DESCRIPTION
## Summary
- cibuildwheel downloads `virtualenv.pyz` from GitHub at build time, which intermittently hits HTTP 429 (Too Many Requests) rate limits
- Adding `CIBW_DEPENDENCY_VERSIONS: "pinned"` makes cibuildwheel use its bundled virtualenv instead of fetching it from GitHub
- Fixes https://github.com/KaHIP/KaHIP/actions/runs/22863047241