### PR TITLE
Use pypa/cibuildwheel action to fix 429 rate limits

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,23 +21,16 @@ jobs:
           fetch-depth: 0  # Fetch all history for setuptools-scm
           fetch-tags: true  # Explicitly fetch tags
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.22.0
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.22.0
+        with:
+          output-dir: wheelhouse
         env:
           # Build for Python 3.8, 3.9, 3.10, 3.11, 3.12
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
           # Skip 32-bit builds and musllinux for now
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           # Pass CMake arguments for building Python module
-          CIBW_DEPENDENCY_VERSIONS: "pinned"
           CIBW_ENVIRONMENT: >
             CMAKE_ARGS="-DBUILDPYTHONMODULE=ON -DNOMPI=ON"
 


### PR DESCRIPTION
## Summary
- The pip-installed `cibuildwheel` CLI downloads virtualenv from GitHub at runtime, which persistently hits HTTP 429 rate limits
- Switching to the official `pypa/cibuildwheel@v2.22.0` GitHub Action bundles dependencies and avoids the download entirely
- Also removes the now-unnecessary `setup-python` and `pip install` steps for the wheel build job

Supersedes the previous `CIBW_DEPENDENCY_VERSIONS: "pinned"` fix which didn't resolve the issue.